### PR TITLE
Fix table alignment in room layout

### DIFF
--- a/client/src/components/Room/TimesTable.js
+++ b/client/src/components/Room/TimesTable.js
@@ -64,6 +64,9 @@ const useStyles = makeStyles((theme) => ({
     borderBottomColor: theme.palette.divider,
     color: theme.palette.text.primary,
   },
+  tableHeaderName: {
+    height: '3rem',
+  },
   tableResultCell: {
     width: '5rem',
     height: '1.7rem',
@@ -173,15 +176,16 @@ function TimesTable({
       <Table stickyHeader className={classes.table} size="small">
         <TableHead className={classes.thead}>
           <TableRow className={classes.tr}>
-            <TableCell className={clsx(classes.td, classes.tableHeaderIndex)}>
+            <TableCell className={clsx(classes.td, classes.tableHeaderIndex,
+              classes.tableHeaderName)}
+            >
               <Typography variant="subtitle2">#</Typography>
             </TableCell>
             {sortedUsers.map((u) => (
               <TableCell
                 key={u.id}
-                className={clsx(classes.td, classes.tableHeaderTime, {
-                  [classes.disabled]: !competing[u.id],
-                })}
+                className={clsx(classes.td, classes.tableHeaderTime,
+                  classes.tableHeaderName)}
               >
                 <User user={u} admin={admin.id === u.id} />
                 <br />

--- a/client/src/components/Room/TimesTable.js
+++ b/client/src/components/Room/TimesTable.js
@@ -29,7 +29,6 @@ const useStyles = makeStyles((theme) => ({
   },
   tbody: {
     flexGrow: 1,
-    overflowY: 'auto',
     height: '0px',
     '&:scollbar': {
       width: 200,
@@ -49,15 +48,7 @@ const useStyles = makeStyles((theme) => ({
   },
   tableHeaderIndex: {
     width: '3rem',
-    flexShrink: 1,
-    height: '1.7rem',
-    backgroundColor: theme.palette.common.green,
-    borderBottomColor: theme.palette.common.greenBorder,
-    color: theme.palette.text.primary,
-  },
-  tableIndexMean: {
-    width: '3rem',
-    flexShrink: 1,
+    flexShrink: 0,
     height: '1.7rem',
     backgroundColor: theme.palette.common.green,
     borderBottomColor: theme.palette.common.greenBorder,
@@ -67,6 +58,8 @@ const useStyles = makeStyles((theme) => ({
     width: '5rem',
     height: '1.7rem',
     flexGrow: 1,
+    flexShrink: 0,
+    flexBasis: '6em',
     backgroundColor: theme.palette.background.default,
     borderBottomColor: theme.palette.divider,
     color: theme.palette.text.primary,
@@ -197,7 +190,7 @@ function TimesTable({
           </TableRow>
 
           <TableRow className={classes.tr}>
-            <TableCell className={clsx(classes.td, classes.tableIndexMean)}>
+            <TableCell className={clsx(classes.td, classes.tableHeaderIndex)}>
               <Typography variant="subtitle2">mean</Typography>
             </TableCell>
             {sortedUsers.map((u) => (


### PR DESCRIPTION
**Summary:**
This PR modifies `client/src/components/Room/TimesTable.js` and does two things to the room layout times table:
- Adds extra height in the name header so that two-line names are given more space.
- Fixes the alignment of rows, especially when a lot of people join a room.
This is done via adjusting `flex` attribute of the table cells.

**Tests:**
- One person in the room:
![image](https://user-images.githubusercontent.com/7027037/80270159-b4c70100-8683-11ea-8bc6-5d804140eae3.png)

- Two people in the room:
![image](https://user-images.githubusercontent.com/7027037/80270178-ef309e00-8683-11ea-8178-7c95f1c4f555.png)

- Multiple people in the room (testing long names):
![image](https://user-images.githubusercontent.com/7027037/80271422-0eccc400-868e-11ea-8894-5cf06fdbcb9f.png)

Unfortunately can't test 10 people in a room unless I can find a way to split multiple incognito sessions locally...