### PR TITLE
Change default penalties' values from undefined to false

### DIFF
--- a/client/src/components/Timer/ManualTimer.js
+++ b/client/src/components/Timer/ManualTimer.js
@@ -77,6 +77,9 @@ class ManualTimer extends React.Component {
         /* inspectionDNF: false, */
         /* DNF: false, */
         /* AUF: false, */
+        AUF: false,
+        DNF: false,
+        inspection: false,
       },
     };
 
@@ -210,7 +213,11 @@ class ManualTimer extends React.Component {
       inspection: 0,
       timeInput: '',
       started: 0,
-      penalties: {},
+      penalties: {
+        AUF: false,
+        DNF: false,
+        inspection: false,
+      },
     });
     this.setStatus(STATUS.RESTING);
   }


### PR DESCRIPTION
Before, the default value of the penalties was `undefined`, which caused issues with the component switching between being controlled and uncontrolled, so the checkbox just didn't know what to do.