### PR TITLE
Fix Netlify client dependency install

### DIFF
--- a/client/netlify.toml
+++ b/client/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "npm ci --ignore-scripts && if node -e \"process.exit(Number(process.versions.node.split('.')[0]) >= 17 ? 0 : 1)\"; then NODE_OPTIONS=--openssl-legacy-provider npm run build; else npm run build; fi"
+  command = "npm ci --ignore-scripts --production=false && if node -e \"process.exit(Number(process.versions.node.split('.')[0]) >= 17 ? 0 : 1)\"; then NODE_OPTIONS=--openssl-legacy-provider npm run build; else npm run build; fi"
   publish = "build"
 
 [build.environment]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   base = "client"
-  command = "npm ci --ignore-scripts && if node -e \"process.exit(Number(process.versions.node.split('.')[0]) >= 17 ? 0 : 1)\"; then NODE_OPTIONS=--openssl-legacy-provider npm run build; else npm run build; fi"
+  command = "npm ci --ignore-scripts --production=false && if node -e \"process.exit(Number(process.versions.node.split('.')[0]) >= 17 ? 0 : 1)\"; then NODE_OPTIONS=--openssl-legacy-provider npm run build; else npm run build; fi"
   publish = "build"
 
 [build.environment]


### PR DESCRIPTION
## Summary
- force Netlify client builds to install devDependencies even when NODE_ENV=production
- keep the root and client-local Netlify configs in sync

## Verification
- netlify build --context production from a clean temporary checkout
- targeted clean client build with NODE_ENV=production CI=true npm ci --ignore-scripts --production=false && npm run build