### PR TITLE
Fix private room reconnect recovery

### DIFF
--- a/client/src/components/Navigation.jsx
+++ b/client/src/components/Navigation.jsx
@@ -40,6 +40,7 @@ export function GlobalPendingResultAlert({
   onDiscard,
   onReturn,
   pendingResult,
+  privateRoom,
   status,
   userId,
 }) {
@@ -54,9 +55,12 @@ export function GlobalPendingResultAlert({
   } else if (status === 'failed') {
     message = `Your saved time could not be submitted: ${error.message}`;
   } else if (atPendingRoom) {
+    const rejoinMessage = privateRoom
+      ? 'Enter the room password below to rejoin and submit it.'
+      : 'Rejoin the room to submit it.';
     message = canDiscardResult
-      ? 'Your time is still saved on this device, but its room is not currently joined. Restore access to the room or discard the saved result.'
-      : 'Your time may already be submitting, but its room is not currently joined. Restore access to the room to finish it.';
+      ? `Your time is still saved on this device. ${rejoinMessage}`
+      : `Your time may already be submitting. ${rejoinMessage}`;
   } else {
     message = canDiscardResult
       ? `Your saved time is waiting in room ${pendingResult.roomId}. Return there to submit it, or discard it.`
@@ -99,12 +103,14 @@ GlobalPendingResultAlert.propTypes = {
     submissionId: PropTypes.string,
     userId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   }).isRequired,
+  privateRoom: PropTypes.bool,
   status: PropTypes.oneOf(['pending', 'sending', 'failed']).isRequired,
   userId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 GlobalPendingResultAlert.defaultProps = {
   error: null,
+  privateRoom: false,
   userId: undefined,
 };
 
@@ -207,6 +213,7 @@ function Navigation({
             onDiscard={() => dispatch(discardPendingResult(pendingResult.submissionId))}
             onReturn={() => dispatch(push(pendingRoomPath))}
             pendingResult={pendingResult}
+            privateRoom={!!room.private}
             status={resultSubmission.status}
             userId={user.id}
           />

--- a/client/src/components/Navigation.test.jsx
+++ b/client/src/components/Navigation.test.jsx
@@ -45,13 +45,14 @@ describe('global pending result alert', () => {
         onDiscard={onDiscard}
         onReturn={jest.fn()}
         pendingResult={pendingResult}
+        privateRoom
         status="pending"
         userId={42}
       />,
     );
     const actions = shallow(<div>{wrapper.find(Alert).prop('action')}</div>);
 
-    expect(wrapper.text()).toContain('room is not currently joined');
+    expect(wrapper.text()).toContain('Enter the room password below');
     expect(actions.find(Button)).toHaveLength(1);
     expect(actions.find(Button).text()).toBe('Discard saved result');
 

--- a/client/src/components/Room/Common/Login.jsx
+++ b/client/src/components/Room/Common/Login.jsx
@@ -22,21 +22,12 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-function Login({ dispatch, roomId, loginFailed }) {
+function Login({ dispatch, roomId, joinError }) {
   const classes = useStyles();
   const [password, setPassword] = useState('');
-  const [resetPassword, setResetPassword] = useState(false);
-
-  // Forgive me lord
-  if (loginFailed && password && !resetPassword) {
-    setPassword('');
-
-    setResetPassword(true);
-  }
 
   const login = (event) => {
     event.preventDefault();
-    setResetPassword(false);
     dispatch(joinRoom({
       id: roomId,
       password,
@@ -47,8 +38,8 @@ function Login({ dispatch, roomId, loginFailed }) {
     setPassword(event.target.value);
   };
 
-  const helperText = (loginFailed && loginFailed.error)
-    ? loginFailed.error.message : 'Enter password to login';
+  const helperText = joinError
+    ? joinError.message : 'Enter password to login';
 
   return (
     <Paper className={classes.root} elevation={1}>
@@ -77,7 +68,7 @@ function Login({ dispatch, roomId, loginFailed }) {
             type="password"
             autoFocus
             helperText={helperText}
-            error={!!loginFailed}
+            error={!!joinError}
             value={password}
             onChange={updatePassword}
           />
@@ -96,18 +87,20 @@ function Login({ dispatch, roomId, loginFailed }) {
 
 Login.propTypes = {
   roomId: PropTypes.string,
-  loginFailed: PropTypes.shape(),
+  joinError: PropTypes.shape({
+    message: PropTypes.string,
+  }),
   dispatch: PropTypes.func.isRequired,
 };
 
 Login.defaultProps = {
   roomId: undefined,
-  loginFailed: null,
+  joinError: null,
 };
 
 const mapStateToProps = (state) => ({
   roomId: state.room._id,
-  loginFailed: state.socket.loginFailed,
+  joinError: state.room.joinError,
 });
 
 export default connect(mapStateToProps)(Login);

--- a/client/src/components/RoomConfigureDialog.jsx
+++ b/client/src/components/RoomConfigureDialog.jsx
@@ -47,7 +47,7 @@ function RoomConfigureDialog({
   const classes = useStyles();
   const [stateName, setName] = React.useState(room.name);
   const [statePrivate, setPrivate] = React.useState(room.private);
-  const [statePassword, setPassword] = React.useState(room.private ? room.accessCode : null);
+  const [statePassword, setPassword] = React.useState('');
   const [stateType, setType] = React.useState(room.type);
   const [stateRequireRI, setRequireRI] = React.useState(room.requireRevealedIdentity);
   const [stateStartTime, setStartTime] = React.useState(room.startTime ? (
@@ -58,7 +58,7 @@ function RoomConfigureDialog({
   const handleCancel = () => {
     setName(room.name);
     setPrivate(room.private);
-    setPassword(null);
+    setPassword('');
     setType(room.type);
     setRequireRI(room.requireRevealedIdentity);
     setStartTime(room.startTime ? (
@@ -73,14 +73,14 @@ function RoomConfigureDialog({
     onSave({
       name: stateName,
       private: statePrivate,
-      password: statePrivate ? statePassword : null,
+      password: statePrivate ? statePassword || undefined : null,
       type: stateType,
       requireRevealedIdentity: stateRequireRI,
       startTime: stateStartTime ? new Date(stateStartTime) : null,
       twitchChannel: stateTwitchChannel,
     });
 
-    setPassword(null);
+    setPassword('');
     onCancel(); // Close the dialog box
   };
 
@@ -132,7 +132,9 @@ function RoomConfigureDialog({
           type="password"
           disabled={!statePrivate}
           onChange={handlePasswordChange}
-          // autoFocus
+          value={statePassword}
+          helperText={room.private && statePrivate ? 'Leave blank to keep the current password.' : undefined}
+          autoComplete="new-password"
           fullWidth
         />
       </DialogContent>
@@ -203,7 +205,11 @@ function RoomConfigureDialog({
       <Divider />
       <DialogActions>
         <Button onClick={handleCancel} color="secondary">Cancel</Button>
-        <Button onClick={handleSave} color="primary" disabled={!stateName || (statePrivate && !statePassword)}>
+        <Button
+          onClick={handleSave}
+          color="primary"
+          disabled={!stateName || (statePrivate && !room.private && !statePassword)}
+        >
           {room._id ? 'Save' : 'Create'}
         </Button>
       </DialogActions>
@@ -216,7 +222,6 @@ RoomConfigureDialog.propTypes = {
     _id: PropTypes.string,
     name: PropTypes.string,
     private: PropTypes.bool,
-    accessCode: PropTypes.string,
     type: PropTypes.string,
     requireRevealedIdentity: PropTypes.bool,
     startTime: PropTypes.string,
@@ -232,7 +237,6 @@ RoomConfigureDialog.defaultProps = {
     _id: undefined,
     name: '',
     private: false,
-    accessCode: null,
     type: 'normal',
     requireRevealedIdentity: false,
     startTime: '',

--- a/client/src/components/RoomConfigureDialog.test.jsx
+++ b/client/src/components/RoomConfigureDialog.test.jsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Button from '@material-ui/core/Button';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import TextField from '@material-ui/core/TextField';
+import RoomConfigureDialog from './RoomConfigureDialog';
+
+const privateRoom = {
+  _id: 'room-one',
+  name: 'Private room',
+  private: true,
+  type: 'normal',
+  requireRevealedIdentity: false,
+  startTime: '',
+  twitchChannel: '',
+};
+
+describe('RoomConfigureDialog passwords', () => {
+  it('allows an existing private room to be edited without replacing its password', () => {
+    const onSave = jest.fn();
+    const wrapper = shallow(
+      <RoomConfigureDialog
+        room={privateRoom}
+        open
+        onSave={onSave}
+        onCancel={jest.fn()}
+      />,
+    );
+
+    const save = wrapper.find(Button).filterWhere((button) => button.text() === 'Save');
+    expect(save.prop('disabled')).toBe(false);
+    save.simulate('click');
+
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({
+      private: true,
+      password: undefined,
+    }));
+  });
+
+  it('sends an explicitly changed password', () => {
+    const onSave = jest.fn();
+    const wrapper = shallow(
+      <RoomConfigureDialog
+        room={privateRoom}
+        open
+        onSave={onSave}
+        onCancel={jest.fn()}
+      />,
+    );
+
+    wrapper.find(TextField).findWhere((field) => field.prop('id') === 'password')
+      .simulate('change', { target: { value: 'new-password' } });
+    wrapper.find(Button).filterWhere((button) => button.text() === 'Save').simulate('click');
+
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({
+      private: true,
+      password: 'new-password',
+    }));
+  });
+
+  it('requires a password when making an existing public room private', () => {
+    const wrapper = shallow(
+      <RoomConfigureDialog
+        room={{ ...privateRoom, private: false }}
+        open
+        onSave={jest.fn()}
+        onCancel={jest.fn()}
+      />,
+    );
+
+    wrapper.find(FormControlLabel).first().prop('control').props.onChange();
+    wrapper.update();
+
+    const save = wrapper.find(Button).filterWhere((button) => button.text() === 'Save');
+    expect(save.prop('disabled')).toBe(true);
+  });
+
+  it('requires a password when creating a private room', () => {
+    const wrapper = shallow(
+      <RoomConfigureDialog
+        open
+        onSave={jest.fn()}
+        onCancel={jest.fn()}
+      />,
+    );
+
+    wrapper.find(FormControlLabel).first().prop('control').props.onChange();
+    wrapper.update();
+
+    const create = wrapper.find(Button).filterWhere((button) => button.text() === 'Create');
+    expect(create.prop('disabled')).toBe(true);
+  });
+});

--- a/client/src/store/middlewares/rooms.js
+++ b/client/src/store/middlewares/rooms.js
@@ -23,6 +23,7 @@ import {
   UPDATE_USER,
   DISCARD_PENDING_RESULT,
   joinRoom,
+  roomJoinFailed,
   roomUpdated,
   resetRoom,
   userJoined,
@@ -49,6 +50,11 @@ import {
   persistPendingResult,
   readPendingResult,
 } from '../room/resultOutbox';
+import {
+  clearRoomPassword,
+  persistRoomPassword,
+  readRoomPassword,
+} from '../room/roomPasswordStorage';
 import {
   ROOMS_CONNECT,
   ROOMS_DISCONNECT,
@@ -94,6 +100,7 @@ export const createRoomsNamespaceMiddleware = ({
   let submissionRetryTimer = null;
   let hydratedPendingResult = false;
   let storageWarningSubmissionId = null;
+  let passwordStorageWarningRoomId = null;
 
   const currentSubmission = () => store.getState().room.resultSubmission;
   const readStoredPendingResult = () => {
@@ -102,6 +109,73 @@ export const createRoomsNamespaceMiddleware = ({
     } catch (storageError) {
       return null;
     }
+  };
+
+  const readStoredRoomPassword = (roomId) => {
+    try {
+      return readRoomPassword(roomId, storage);
+    } catch (storageError) {
+      return null;
+    }
+  };
+
+  const forgetRoomPassword = (roomId) => {
+    try {
+      clearRoomPassword(roomId, storage);
+    } catch (storageError) {
+      // The next invalid join will try again.
+    }
+  };
+
+  const warnPasswordStorage = (roomId) => {
+    if (passwordStorageWarningRoomId === String(roomId)) {
+      return;
+    }
+
+    passwordStorageWarningRoomId = String(roomId);
+    store.dispatch(createMessage({
+      severity: 'warning',
+      text: 'Room password storage is unavailable on this device.',
+    }));
+  };
+
+  const rememberRoomPassword = (roomId, password) => {
+    if (!password) {
+      return;
+    }
+
+    try {
+      persistRoomPassword(roomId, password, storage);
+    } catch (storageError) {
+      warnPasswordStorage(roomId);
+    }
+  };
+
+  const applySuccessfulRoomEdit = (room, options) => {
+    const updatedRoom = room || store.getState().room;
+    const roomId = updatedRoom._id || store.getState().room._id;
+    if (options.private === false || updatedRoom.private === false) {
+      forgetRoomPassword(roomId);
+      store.dispatch(roomUpdated({
+        ...updatedRoom,
+        password: null,
+      }));
+      return;
+    }
+
+    if (options.password) {
+      rememberRoomPassword(roomId, options.password);
+      store.dispatch(roomUpdated({
+        ...updatedRoom,
+        password: options.password,
+      }));
+      return;
+    }
+
+    store.dispatch(roomUpdated({
+      ...updatedRoom,
+      password: store.getState().room.password || readStoredRoomPassword(roomId),
+    }));
   };
 
   const warnPendingResultNotBackedUp = (submissionId) => {
@@ -299,7 +373,6 @@ export const createRoomsNamespaceMiddleware = ({
     const { room } = store.getState();
     const request = pendingJoinRequest || (room.accessCode ? {
       id: room._id,
-      password: room.password,
     } : null);
 
     if (request) {
@@ -351,6 +424,15 @@ export const createRoomsNamespaceMiddleware = ({
         store.dispatch(roomsUpdated(rooms));
       },
       [Protocol.UPDATE_ROOM]: (room) => {
+        if (room.private === false) {
+          forgetRoomPassword(room._id);
+          store.dispatch(roomUpdated({
+            ...room,
+            password: null,
+          }));
+          return;
+        }
+
         store.dispatch(roomUpdated(room));
       },
       [Protocol.GLOBAL_ROOM_UPDATED]: (room) => {
@@ -360,6 +442,7 @@ export const createRoomsNamespaceMiddleware = ({
         store.dispatch(roomCreated(room));
       },
       [Protocol.ROOM_DELETED]: (room) => {
+        forgetRoomPassword(room);
         store.dispatch(roomDeleted(room));
         if (room === store.getState().room._id) {
           store.dispatch(push('/'));
@@ -488,15 +571,25 @@ export const createRoomsNamespaceMiddleware = ({
             severity: 'error',
             text: err.message,
           }));
+          return;
         }
+
+        forgetRoomPassword(id);
       });
     },
     [JOIN_ROOM]: ({ id, password }) => {
+      const storedPassword = readStoredRoomPassword(id);
+      const roomPassword = password || storedPassword;
       const generation = joinGeneration + 1;
       joinGeneration = generation;
       joinedRoomId = null;
       pendingJoinRequest = { id, password };
-      namespace.emit(Protocol.JOIN_ROOM, { id, password }, (err, room) => {
+
+      if (!roomsConnected) {
+        return;
+      }
+
+      namespace.emit(Protocol.JOIN_ROOM, { id, password: roomPassword }, (err, room) => {
         if (generation !== joinGeneration) {
           return;
         }
@@ -504,10 +597,29 @@ export const createRoomsNamespaceMiddleware = ({
         pendingJoinRequest = null;
 
         if (err) {
+          if (err.reason === 'not_found' || err.statusCode === 404) {
+            forgetRoomPassword(id);
+          }
+
+          const invalidPassword = err.reason === 'invalid_password'
+            || /invalid password/i.test(err.message || '');
+          if (invalidPassword && storedPassword === roomPassword) {
+            forgetRoomPassword(id);
+          }
+
+          const passwordAccessError = err.reason === 'password_required'
+            || err.reason === 'invalid_password'
+            || (room && room.private && err.statusCode === 403
+              && /password/i.test(err.message || ''));
+          if (room && passwordAccessError) {
+            store.dispatch(roomUpdated(room));
+          }
+
           if (err.banned) {
             store.dispatch(push('/'));
           }
 
+          store.dispatch(roomJoinFailed(err));
           store.dispatch(createMessage({
             severity: 'error',
             text: err.message,
@@ -516,8 +628,18 @@ export const createRoomsNamespaceMiddleware = ({
         }
 
         if (room) {
-          store.dispatch(roomUpdated(room));
-          joinedRoomId = room._id || id;
+          const joinedRoomIdValue = room._id || id;
+          if (room.private) {
+            rememberRoomPassword(joinedRoomIdValue, roomPassword);
+          } else {
+            forgetRoomPassword(joinedRoomIdValue);
+          }
+
+          store.dispatch(roomUpdated({
+            ...room,
+            password: room.private ? roomPassword || null : null,
+          }));
+          joinedRoomId = joinedRoomIdValue;
           flushPendingResult();
 
           if (room.accessCode) {
@@ -539,7 +661,13 @@ export const createRoomsNamespaceMiddleware = ({
           return;
         }
 
-        store.dispatch(roomUpdated(room));
+        if (room.private) {
+          rememberRoomPassword(room._id, options.password);
+        }
+        store.dispatch(roomUpdated({
+          ...room,
+          password: room.private ? options.password : null,
+        }));
         joinedRoomId = room._id;
         store.dispatch(push(`/rooms/${room._id}`));
         flushPendingResult();
@@ -637,7 +765,17 @@ export const createRoomsNamespaceMiddleware = ({
       namespace.emit(Protocol.CHANGE_EVENT, event);
     },
     [EDIT_ROOM]: ({ options }) => {
-      namespace.emit(Protocol.EDIT_ROOM, options);
+      namespace.emit(Protocol.EDIT_ROOM, options, (err, room) => {
+        if (err) {
+          store.dispatch(createMessage({
+            severity: 'error',
+            text: err.message,
+          }));
+          return;
+        }
+
+        applySuccessfulRoomEdit(room, options);
+      });
     },
     [SEND_CHAT]: ({ message }) => {
       namespace.emit(Protocol.MESSAGE, message);

--- a/client/src/store/middlewares/rooms.test.js
+++ b/client/src/store/middlewares/rooms.test.js
@@ -7,10 +7,11 @@ import roomsReducer from '../rooms/reducer';
 import messagesReducer from '../messages/reducers';
 import {
   discardPendingResult,
+  editRoom,
   joinRoom,
   submitResult,
 } from '../room/actions';
-import { connectSocket } from '../rooms/actions';
+import { connectSocket, createRoom } from '../rooms/actions';
 import {
   PENDING_RESULT_STORAGE_KEY,
   createPendingResult,
@@ -18,6 +19,10 @@ import {
   markPendingResultFailed,
   persistPendingResult,
 } from '../room/resultOutbox';
+import {
+  persistRoomPassword,
+  readRoomPassword,
+} from '../room/roomPasswordStorage';
 import { createRoomsNamespaceMiddleware } from './rooms';
 
 jest.mock('./manager', () => ({
@@ -153,7 +158,7 @@ const result = {
   },
 };
 
-describe('rooms result outbox middleware', () => {
+describe('rooms middleware', () => {
   beforeEach(() => {
     window.localStorage.clear();
   });
@@ -168,6 +173,358 @@ describe('rooms result outbox middleware', () => {
     expect(emissionsFor(namespace, Protocol.JOIN_ROOM)).toHaveLength(1);
     expect(store.getState().room.fetching).toBe(false);
     expect(store.getState().room.attempts).toBe(attempts);
+  });
+
+  it('waits for the socket connection before emitting the initial room join', () => {
+    const { namespace, store } = buildStore({
+      roomState: {
+        ...initialRoom(),
+        _id: null,
+        accessCode: null,
+      },
+    });
+    store.dispatch(connectSocket());
+    store.dispatch(joinRoom({ id: 'room-two', password: 'secret' }));
+
+    expect(emissionsFor(namespace, Protocol.JOIN_ROOM)).toHaveLength(0);
+
+    namespace.options.onConnected();
+
+    const joins = emissionsFor(namespace, Protocol.JOIN_ROOM);
+    expect(joins).toHaveLength(1);
+    expect(joins[0].args[0]).toEqual({ id: 'room-two', password: 'secret' });
+  });
+
+  it('uses a saved private room password after a refresh', () => {
+    persistRoomPassword('private-room', 'saved-password');
+    const { namespace, store } = buildStore({
+      roomState: {
+        ...initialRoom(),
+        _id: null,
+        accessCode: null,
+      },
+    });
+    store.dispatch(connectSocket());
+    namespace.options.onConnected();
+    store.dispatch(joinRoom({ id: 'private-room' }));
+
+    const join = emissionsFor(namespace, Protocol.JOIN_ROOM)[0];
+    expect(join.args[0]).toEqual({
+      id: 'private-room',
+      password: 'saved-password',
+    });
+
+    const joinedRoom = {
+      ...initialRoom(),
+      _id: 'private-room',
+      accessCode: 'PRIVATE',
+      private: true,
+    };
+    delete joinedRoom.resultSubmission;
+    join.args[1](null, joinedRoom);
+
+    expect(store.getState().room.password).toBe('saved-password');
+    expect(readRoomPassword('private-room')).toBe('saved-password');
+  });
+
+  it('remembers a successful private room password', () => {
+    const roomState = {
+      ...initialRoom(),
+      _id: null,
+      accessCode: null,
+    };
+    const built = buildStore({ roomState });
+    built.store.dispatch(connectSocket());
+    built.namespace.options.onConnected();
+    built.store.dispatch(joinRoom({ id: 'private-room', password: 'secret' }));
+
+    const join = emissionsFor(built.namespace, Protocol.JOIN_ROOM)[0];
+    const joinedRoom = {
+      ...initialRoom(),
+      _id: 'private-room',
+      accessCode: 'PRIVATE',
+      private: true,
+    };
+    delete joinedRoom.resultSubmission;
+    join.args[1](null, joinedRoom);
+    expect(readRoomPassword('private-room')).toBe('secret');
+    expect(built.store.getState().room.password).toBe('secret');
+  });
+
+  it('clears a rejected stored password and shows the password form', () => {
+    persistRoomPassword('private-room', 'stale-password');
+    const { namespace, store } = buildStore({
+      roomState: {
+        ...initialRoom(),
+        _id: null,
+        accessCode: null,
+      },
+    });
+    store.dispatch(connectSocket());
+    namespace.options.onConnected();
+    store.dispatch(joinRoom({ id: 'private-room' }));
+
+    const joins = emissionsFor(namespace, Protocol.JOIN_ROOM);
+    expect(joins).toHaveLength(1);
+    expect(joins[0].args[0]).toEqual({
+      id: 'private-room',
+      password: 'stale-password',
+    });
+
+    joins[0].args[1]({
+      statusCode: 403,
+      message: 'Invalid password',
+      reason: 'invalid_password',
+    }, {
+      _id: 'private-room',
+      name: 'Private room',
+      private: true,
+      type: 'normal',
+    });
+
+    expect(readRoomPassword('private-room')).toBeNull();
+    expect(emissionsFor(namespace, Protocol.JOIN_ROOM)).toHaveLength(1);
+    expect(store.getState().room).toMatchObject({
+      _id: 'private-room',
+      private: true,
+      fetching: false,
+    });
+    expect(store.getState().room.joinError.message).toBe('Invalid password');
+  });
+
+  it('remembers the password for a newly created private room', () => {
+    const { namespace, store } = buildStore();
+    store.dispatch(connectSocket());
+    namespace.options.onConnected();
+    store.dispatch(createRoom({
+      name: 'Private room',
+      password: 'new-password',
+      private: true,
+      type: 'normal',
+    }));
+
+    const creation = emissionsFor(namespace, Protocol.CREATE_ROOM)[0];
+    creation.args[1](null, {
+      ...initialRoom(),
+      _id: 'new-private-room',
+      accessCode: 'NEWPRIVATE',
+      private: true,
+    });
+
+    expect(readRoomPassword('new-private-room')).toBe('new-password');
+    expect(store.getState().room.password).toBe('new-password');
+  });
+
+  it('remembers a changed private room password after the edit succeeds', () => {
+    persistRoomPassword('room-one', 'old-password');
+    const { namespace, store } = buildStore({
+      roomState: {
+        ...initialRoom(),
+        private: true,
+        password: 'old-password',
+      },
+    });
+    store.dispatch(editRoom({
+      name: 'Private room',
+      private: true,
+      password: 'new-password',
+      type: 'normal',
+    }));
+
+    const edit = emissionsFor(namespace, Protocol.EDIT_ROOM)[0];
+    expect(readRoomPassword('room-one')).toBe('old-password');
+
+    edit.args[1](null, {
+      ...initialRoom(),
+      private: true,
+    });
+
+    expect(readRoomPassword('room-one')).toBe('new-password');
+    expect(store.getState().room.password).toBe('new-password');
+  });
+
+  it('keeps the saved password when an edit does not replace it', () => {
+    persistRoomPassword('room-one', 'existing-password');
+    const { namespace, store } = buildStore({
+      roomState: {
+        ...initialRoom(),
+        private: true,
+        password: 'existing-password',
+      },
+    });
+    store.dispatch(editRoom({
+      name: 'Renamed room',
+      private: true,
+      password: undefined,
+      type: 'normal',
+    }));
+
+    const edit = emissionsFor(namespace, Protocol.EDIT_ROOM)[0];
+    edit.args[1](null, {
+      ...initialRoom(),
+      name: 'Renamed room',
+      private: true,
+    });
+
+    expect(readRoomPassword('room-one')).toBe('existing-password');
+    expect(store.getState().room.password).toBe('existing-password');
+  });
+
+  it('keeps the saved password when a private room edit fails', () => {
+    persistRoomPassword('room-one', 'existing-password');
+    const { namespace, store } = buildStore({
+      roomState: {
+        ...initialRoom(),
+        private: true,
+        password: 'existing-password',
+      },
+    });
+    store.dispatch(editRoom({
+      name: 'Private room',
+      private: true,
+      password: 'rejected-password',
+      type: 'normal',
+    }));
+
+    const edit = emissionsFor(namespace, Protocol.EDIT_ROOM)[0];
+    edit.args[1]({
+      statusCode: 500,
+      message: 'Failed to edit room',
+    });
+
+    expect(readRoomPassword('room-one')).toBe('existing-password');
+    expect(store.getState().room.password).toBe('existing-password');
+  });
+
+  it('clears the saved password after making a room public', () => {
+    persistRoomPassword('room-one', 'existing-password');
+    const { namespace, store } = buildStore({
+      roomState: {
+        ...initialRoom(),
+        private: true,
+        password: 'existing-password',
+      },
+    });
+    store.dispatch(editRoom({
+      name: 'Public room',
+      private: false,
+      password: null,
+      type: 'normal',
+    }));
+
+    const edit = emissionsFor(namespace, Protocol.EDIT_ROOM)[0];
+    expect(readRoomPassword('room-one')).toBe('existing-password');
+
+    edit.args[1](null, {
+      ...initialRoom(),
+      name: 'Public room',
+      private: false,
+    });
+
+    expect(readRoomPassword('room-one')).toBeNull();
+    expect(store.getState().room.password).toBeNull();
+  });
+
+  it('clears the saved password when a room update makes it public', () => {
+    persistRoomPassword('room-one', 'existing-password');
+    const { namespace, store } = buildStore({
+      roomState: {
+        ...initialRoom(),
+        private: true,
+        password: 'existing-password',
+      },
+    });
+
+    namespace.options.events[Protocol.UPDATE_ROOM]({
+      ...initialRoom(),
+      private: false,
+    });
+
+    expect(readRoomPassword('room-one')).toBeNull();
+    expect(store.getState().room.password).toBeNull();
+  });
+
+  it('loads the private room mask when a password is required', () => {
+    const { namespace, store } = buildStore({
+      roomState: {
+        ...initialRoom(),
+        _id: null,
+        accessCode: null,
+      },
+    });
+    store.dispatch(connectSocket());
+    namespace.options.onConnected();
+    store.dispatch(joinRoom({ id: 'private-room' }));
+
+    const join = emissionsFor(namespace, Protocol.JOIN_ROOM)[0];
+    join.args[1]({
+      statusCode: 403,
+      message: 'Room requires password to join',
+    }, {
+      _id: 'private-room',
+      name: 'Private room',
+      private: true,
+      type: 'normal',
+    });
+
+    expect(store.getState().room).toMatchObject({
+      _id: 'private-room',
+      fetching: false,
+      private: true,
+    });
+    expect(emissionsFor(namespace, Protocol.SUBMIT_RESULT)).toHaveLength(0);
+  });
+
+  it('submits a restored result after private room access is restored', () => {
+    persistPendingResult(createPendingResult({
+      userId: 42,
+      roomId: 'private-room',
+      attemptId: 12,
+      attemptKey: 'attempt-one',
+      result: { time: 1234, penalties: {} },
+    }, {
+      createId: () => 'restored-submission',
+      now: () => 500,
+    }));
+    const { namespace, store } = buildStore({
+      roomState: {
+        ...initialRoom(),
+        _id: null,
+        accessCode: null,
+      },
+    });
+    store.dispatch(connectSocket());
+    namespace.options.onConnected();
+    store.dispatch(joinRoom({ id: 'private-room' }));
+
+    let join = emissionsFor(namespace, Protocol.JOIN_ROOM)[0];
+    join.args[1]({
+      statusCode: 403,
+      message: 'Room requires password to join',
+      reason: 'password_required',
+    }, {
+      _id: 'private-room',
+      name: 'Private room',
+      private: true,
+      type: 'normal',
+    });
+
+    expect(emissionsFor(namespace, Protocol.SUBMIT_RESULT)).toHaveLength(0);
+
+    store.dispatch(joinRoom({ id: 'private-room', password: 'secret' }));
+    [, join] = emissionsFor(namespace, Protocol.JOIN_ROOM);
+    const joinedRoom = {
+      ...initialRoom(),
+      _id: 'private-room',
+      accessCode: 'PRIVATE',
+      private: true,
+    };
+    delete joinedRoom.resultSubmission;
+    join.args[1](null, joinedRoom);
+
+    const submissions = emissionsFor(namespace, Protocol.SUBMIT_RESULT);
+    expect(submissions).toHaveLength(1);
+    expect(submissions[0].args[0].submissionId).toBe('restored-submission');
   });
 
   it('persists while disconnected and submits only after the room join acknowledgement', () => {

--- a/client/src/store/room/actions.js
+++ b/client/src/store/room/actions.js
@@ -2,6 +2,7 @@ export const ROOM_UPDATED = 'room/updated';
 export const RESET_ROOM = 'room/reset';
 export const DELETE_ROOM = 'room/delete';
 export const JOIN_ROOM = 'room/join';
+export const ROOM_JOIN_FAILED = 'room/join_failed';
 export const LEAVE_ROOM = 'room/leave';
 export const SUBMIT_RESULT = 'room/submit_result';
 export const NEW_RESULT = 'room/new_result';
@@ -56,6 +57,11 @@ export const joinRoom = ({
   spectating,
   password,
   reconnecting,
+});
+
+export const roomJoinFailed = (error) => ({
+  type: ROOM_JOIN_FAILED,
+  error,
 });
 
 // We're submitting a new result

--- a/client/src/store/room/reducer.js
+++ b/client/src/store/room/reducer.js
@@ -5,6 +5,7 @@ import {
   USER_LEFT,
   LEAVE_ROOM,
   JOIN_ROOM,
+  ROOM_JOIN_FAILED,
   NEW_ATTEMPT,
   NEW_RESULT,
   EDIT_RESULT,
@@ -58,6 +59,7 @@ const INITIAL_STATE = {
   registeredUsers: 0,
   twitchChannel: '',
   resultSubmission: EMPTY_RESULT_SUBMISSION,
+  joinError: null,
 };
 
 const editResult = (state, action) => {
@@ -115,6 +117,11 @@ const reducers = {
     ...state,
     fetching: action.reconnecting ? state.fetching : true,
     password: action.password,
+    joinError: null,
+  }),
+  [ROOM_JOIN_FAILED]: (state, action) => ({
+    ...state,
+    joinError: action.error,
   }),
   [RESET_ROOM]: (state) => ({
     ...INITIAL_STATE,

--- a/client/src/store/room/reducer.test.js
+++ b/client/src/store/room/reducer.test.js
@@ -1,4 +1,4 @@
-import { joinRoom, newResult } from './actions';
+import { joinRoom, newResult, roomJoinFailed } from './actions';
 import roomReducer from './reducer';
 
 const initialState = () => ({
@@ -62,5 +62,14 @@ describe('room joins', () => {
 
     expect(state.fetching).toBe(false);
     expect(state.attempts).toBe(loadedRoom.attempts);
+  });
+
+  it('shows a join error until the next attempt', () => {
+    const failedState = roomReducer(undefined, roomJoinFailed({
+      message: 'Invalid password',
+    }));
+
+    expect(failedState.joinError).toEqual({ message: 'Invalid password' });
+    expect(roomReducer(failedState, joinRoom({ id: 'room-1' })).joinError).toBeNull();
   });
 });

--- a/client/src/store/room/roomPasswordStorage.js
+++ b/client/src/store/room/roomPasswordStorage.js
@@ -1,0 +1,32 @@
+export const ROOM_PASSWORD_STORAGE_PREFIX = 'letscube.roomPassword.v1.';
+
+const storageKey = (roomId) => {
+  if ((typeof roomId !== 'string' && typeof roomId !== 'number')
+    || String(roomId).length === 0) {
+    throw new Error('A room password requires a room ID.');
+  }
+
+  return `${ROOM_PASSWORD_STORAGE_PREFIX}${encodeURIComponent(String(roomId))}`;
+};
+
+export const readRoomPassword = (roomId, storage = window.localStorage) => {
+  const password = storage.getItem(storageKey(roomId));
+  return password || null;
+};
+
+export const persistRoomPassword = (
+  roomId,
+  password,
+  storage = window.localStorage,
+) => {
+  if (typeof password !== 'string' || password.length === 0) {
+    throw new Error('Cannot save an empty room password.');
+  }
+
+  storage.setItem(storageKey(roomId), password);
+  return password;
+};
+
+export const clearRoomPassword = (roomId, storage = window.localStorage) => {
+  storage.removeItem(storageKey(roomId));
+};

--- a/client/src/store/room/roomPasswordStorage.test.js
+++ b/client/src/store/room/roomPasswordStorage.test.js
@@ -1,0 +1,38 @@
+import {
+  ROOM_PASSWORD_STORAGE_PREFIX,
+  clearRoomPassword,
+  persistRoomPassword,
+  readRoomPassword,
+} from './roomPasswordStorage';
+
+describe('private room password storage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('stores passwords separately for each room', () => {
+    persistRoomPassword('room-one', 'first-password');
+    persistRoomPassword('room-two', 'second-password');
+
+    expect(readRoomPassword('room-one')).toBe('first-password');
+    expect(readRoomPassword('room-two')).toBe('second-password');
+    expect(window.localStorage.getItem(
+      `${ROOM_PASSWORD_STORAGE_PREFIX}room-one`,
+    )).toBe('first-password');
+  });
+
+  it('clears a password without affecting other rooms', () => {
+    persistRoomPassword('room-one', 'first-password');
+    persistRoomPassword('room-two', 'second-password');
+
+    clearRoomPassword('room-one');
+
+    expect(readRoomPassword('room-one')).toBeNull();
+    expect(readRoomPassword('room-two')).toBe('second-password');
+  });
+
+  it('rejects missing room IDs and empty passwords', () => {
+    expect(() => persistRoomPassword(null, 'secret')).toThrow('room ID');
+    expect(() => persistRoomPassword('room-one', '')).toThrow('empty room password');
+  });
+});

--- a/server/models/room.js
+++ b/server/models/room.js
@@ -295,9 +295,23 @@ Room.methods.changeEvent = function (event) {
 };
 
 Room.methods.edit = async function (options) {
+  // Older clients sent the room access code when the password field was unchanged.
+  const legacyUnchangedPassword = !!this.password
+    && options.password === this.accessCode;
+  const replacesPassword = typeof options.password === 'string'
+    && options.password.length > 0
+    && !legacyUnchangedPassword;
+  if (options.private && !replacesPassword && !this.password) {
+    const error = new Error('A password is required to make a room private');
+    error.statusCode = 400;
+    throw error;
+  }
+
   this.name = options.name;
   if (options.private) {
-    this.password = await bcrypt.hash(options.password, PASSWORD_SALT_ROUNDS);
+    if (replacesPassword) {
+      this.password = await bcrypt.hash(options.password, PASSWORD_SALT_ROUNDS);
+    }
   } else {
     this.password = null;
   }

--- a/server/models/room.test.js
+++ b/server/models/room.test.js
@@ -39,6 +39,87 @@ describe('room security helpers', () => {
     expect(room.save).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps the existing password when a private room edit leaves it blank', async () => {
+    const password = await bcrypt.hash('existing-password', 4);
+    const room = {
+      password,
+      save: jest.fn().mockResolvedValue(undefined),
+    };
+
+    await Room.methods.edit.call(room, {
+      name: 'Renamed private room',
+      private: true,
+      password: '',
+      type: 'normal',
+      requireRevealedIdentity: false,
+      startTime: null,
+    });
+
+    expect(room.password).toBe(password);
+    expect(room.save).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores the access-code placeholder sent by older clients', async () => {
+    const password = await bcrypt.hash('existing-password', 4);
+    const room = {
+      accessCode: 'ROOM-CODE',
+      password,
+      save: jest.fn().mockResolvedValue(undefined),
+    };
+
+    await Room.methods.edit.call(room, {
+      name: 'Renamed private room',
+      private: true,
+      password: 'ROOM-CODE',
+      type: 'normal',
+      requireRevealedIdentity: false,
+      startTime: null,
+    });
+
+    expect(room.password).toBe(password);
+    expect(room.save).toHaveBeenCalledTimes(1);
+  });
+
+  it('requires a password when making a public room private', async () => {
+    const room = {
+      password: null,
+      save: jest.fn().mockResolvedValue(undefined),
+    };
+
+    await expect(Room.methods.edit.call(room, {
+      name: 'Private room',
+      private: true,
+      password: undefined,
+      type: 'normal',
+      requireRevealedIdentity: false,
+      startTime: null,
+    })).rejects.toMatchObject({
+      message: 'A password is required to make a room private',
+      statusCode: 400,
+    });
+
+    expect(room.save).not.toHaveBeenCalled();
+  });
+
+  it('removes the password when making a private room public', async () => {
+    const room = {
+      password: await bcrypt.hash('existing-password', 4),
+      save: jest.fn().mockResolvedValue(undefined),
+    };
+
+    await Room.methods.edit.call(room, {
+      name: 'Public room',
+      private: false,
+      password: null,
+      type: 'normal',
+      requireRevealedIdentity: false,
+      startTime: null,
+    });
+
+    expect(room.password).toBeNull();
+    expect(room.save).toHaveBeenCalledTimes(1);
+  });
+
   it('marks stale rooms for expiration in ten minutes', async () => {
     const before = Date.now();
     const room = {

--- a/server/socket/middlewares/logger.js
+++ b/server/socket/middlewares/logger.js
@@ -1,12 +1,28 @@
 const logger = require('../../logger');
 
+const redactPasswords = (value) => {
+  if (Array.isArray(value)) {
+    return value.map(redactPasswords);
+  }
+
+  if (!value || typeof value !== 'object'
+    || Object.getPrototypeOf(value) !== Object.prototype) {
+    return value;
+  }
+
+  return Object.entries(value).reduce((redacted, [key, entry]) => ({
+    ...redacted,
+    [key]: /password/i.test(key) ? '[REDACTED]' : redactPasswords(entry),
+  }), {});
+};
+
 module.exports = (socket, next) => {
   socket.onAny((event, data) => {
     logger.info(event, {
       id: socket.id,
       userId: socket.userId,
       roomId: socket.roomId,
-      data,
+      data: redactPasswords(data),
     });
   });
 
@@ -16,3 +32,5 @@ module.exports = (socket, next) => {
 
   next();
 };
+
+module.exports.redactPasswords = redactPasswords;

--- a/server/socket/middlewares/logger.test.js
+++ b/server/socket/middlewares/logger.test.js
@@ -1,0 +1,45 @@
+/* eslint-env jest */
+
+const logger = require('../../logger');
+const loggerMiddleware = require('./logger');
+
+jest.mock('../../logger', () => ({
+  error: jest.fn(),
+  info: jest.fn(),
+}));
+
+describe('socket logger middleware', () => {
+  it('redacts passwords without changing the event payload', () => {
+    const handlers = {};
+    const socket = {
+      id: 'socket-one',
+      userId: 101,
+      roomId: null,
+      onAny: jest.fn((handler) => {
+        handlers.any = handler;
+      }),
+      on: jest.fn((event, handler) => {
+        handlers[event] = handler;
+      }),
+    };
+    const next = jest.fn();
+    const payload = {
+      id: 'room-one',
+      password: 'room-secret',
+      nested: { newPassword: 'another-secret' },
+    };
+
+    loggerMiddleware(socket, next);
+    handlers.any('join_room', payload);
+
+    expect(logger.info).toHaveBeenCalledWith('join_room', expect.objectContaining({
+      data: {
+        id: 'room-one',
+        password: '[REDACTED]',
+        nested: { newPassword: '[REDACTED]' },
+      },
+    }));
+    expect(payload.password).toBe('room-secret');
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/socket/namespaces/rooms.js
+++ b/server/socket/namespaces/rooms.js
@@ -360,6 +360,11 @@ module.exports = (io, middlewares) => {
 
     async function joinRoom(room, cb, spectating) {
       if (socket.roomId) {
+        if (String(socket.roomId) === String(room._id)) {
+          socket.room = socket.room || room;
+          return cb(null, joinRoomMask(socket.room));
+        }
+
         logger.debug('Socket is already in room', { roomId: socket.room._id });
         await metrics.recordRoomJoinFailure({
           room: socket.room,
@@ -445,7 +450,10 @@ module.exports = (io, middlewares) => {
           connectionId: socket.id,
           failureReason,
         });
-        return acknowledgment(error, room ? roomMask(room) : undefined);
+        return acknowledgment({
+          ...error,
+          reason: failureReason,
+        }, room ? roomMask(room) : undefined);
       };
 
       try {
@@ -461,6 +469,18 @@ module.exports = (io, middlewares) => {
           return rejectJoin('grand_prix_disabled', {
             statusCode: 403,
             message: 'Grand Prix rooms are disabled',
+          }, room);
+        }
+
+        if (socket.roomId) {
+          if (String(socket.roomId) === String(room._id)) {
+            socket.room = room;
+            return acknowledgment(null, joinRoomMask(room));
+          }
+
+          return rejectJoin('already_in_room', {
+            statusCode: 400,
+            message: 'Socket is already in room',
           }, room);
         }
 
@@ -792,24 +812,57 @@ module.exports = (io, middlewares) => {
       }).catch(logger.error);
     });
 
-    on(Protocol.EDIT_ROOM, async (options) => {
-      if (!checkAdmin()) {
-        return;
+    on(Protocol.EDIT_ROOM, async (options = {}, cb) => {
+      const acknowledgment = optionalAcknowledgment(cb);
+      const rejectEdit = (error) => {
+        const response = {
+          ...error,
+          event: Protocol.EDIT_ROOM,
+        };
+
+        if (typeof cb === 'function') {
+          return acknowledgment(response);
+        }
+
+        return socket.emit(Protocol.ERROR, response);
+      };
+
+      if (!socket.user) {
+        logger.debug('Unauthenticated user attempting to edit a room');
+        return rejectEdit({
+          statusCode: 403,
+          message: 'Must be logged in',
+        });
+      }
+
+      if (!socket.room) {
+        logger.debug('User not in a room attempting to edit it');
+        return rejectEdit({
+          statusCode: 400,
+          message: 'Must be in a room',
+        });
+      }
+
+      if (socket.room.admin.id !== socket.user.id) {
+        logger.debug('Non-admin attempting to edit a room');
+        return rejectEdit({
+          statusCode: 403,
+          message: 'Must be admin of room',
+        });
       }
 
       if (options.type === 'grand_prix' && !config.grandPrix.enabled) {
         logger.error(`${socket.id} attempted to edit room to grand_prix`);
-        socket.emit(Protocol.ERROR, {
+        return rejectEdit({
           statusCode: 403,
-          event: Protocol.EDIT_ROOM,
           message: 'Grand Prix rooms are disabled',
         });
-        return;
       }
 
       try {
         const room = await socket.room.edit(options);
         ns().in(room.accessCode).emit(Protocol.UPDATE_ROOM, joinRoomMask(room));
+        acknowledgment(null, joinRoomMask(room));
 
         Room.find().then((rooms) => {
           ns().emit(
@@ -818,7 +871,11 @@ module.exports = (io, middlewares) => {
           );
         });
       } catch (e) {
-        (logger.error(e));
+        logger.error(e);
+        return rejectEdit({
+          statusCode: e.statusCode || 500,
+          message: e.statusCode ? e.message : 'Failed to edit room',
+        });
       }
     });
 

--- a/server/socket/namespaces/rooms.test.js
+++ b/server/socket/namespaces/rooms.test.js
@@ -1,0 +1,275 @@
+/* eslint-env jest */
+
+const Protocol = require('../../../client/src/lib/protocol.json');
+const metrics = require('../../metrics');
+const { Room, User } = require('../../models');
+const initRooms = require('./rooms');
+
+jest.mock('../../runtimeConfig', () => ({
+  grandPrix: { enabled: false },
+  socketio: { reconnectGraceMs: 60000 },
+}));
+jest.mock('../../logger', () => ({
+  debug: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+}));
+jest.mock('../../metrics', () => ({
+  beginRoomVisit: jest.fn(),
+  endRoomVisit: jest.fn(),
+  recordRoomCreated: jest.fn(),
+  recordRoomJoinFailure: jest.fn(),
+}));
+jest.mock('../../models', () => ({
+  Room: {
+    find: jest.fn(),
+    findById: jest.fn(),
+  },
+  User: {
+    find: jest.fn(),
+  },
+}));
+jest.mock('../../postgres/dualWrite', () => ({
+  markRoomDeleted: jest.fn(),
+}));
+jest.mock('../lib/reconnectGrace', () => ({
+  createReconnectGrace: jest.fn(() => ({
+    cancel: jest.fn().mockResolvedValue(false),
+    finalize: jest.fn(),
+    schedule: jest.fn(),
+    startReconciliation: jest.fn(),
+  })),
+}));
+jest.mock('../lib/socketHandler', () => ({
+  createSafeSocketHandler: (socket) => (event, handler) => socket.on(event, handler),
+  optionalAcknowledgment: (acknowledgment) => (
+    typeof acknowledgment === 'function' ? acknowledgment : () => {}
+  ),
+}));
+
+const queryResult = (value) => {
+  const query = {
+    populate: jest.fn(() => query),
+    then: (resolve, reject) => Promise.resolve(value).then(resolve, reject),
+  };
+  return query;
+};
+
+const makeRoom = (overrides = {}) => ({
+  _id: 'room-one',
+  accessCode: 'PRIVATE',
+  private: true,
+  password: 'bcrypt-hash-one',
+  type: 'normal',
+  owner: { id: 101 },
+  admin: { id: 101 },
+  users: [],
+  usersInRoom: [],
+  inRoom: new Map(),
+  banned: new Map(),
+  registered: new Map(),
+  requireRevealedIdentity: false,
+  usersLength: 1,
+  authenticate: jest.fn().mockResolvedValue(true),
+  addUser: jest.fn().mockResolvedValue(false),
+  ...overrides,
+});
+
+const makeSocket = ({
+  id, session, userId = 202,
+}) => {
+  const handlers = {};
+  return {
+    id,
+    userId,
+    user: {
+      id: userId,
+      name: `User ${userId}`,
+      showWCAID: true,
+    },
+    handshake: { session },
+    handlers,
+    broadcast: {
+      to: jest.fn(() => ({ emit: jest.fn() })),
+    },
+    emit: jest.fn(),
+    join: jest.fn(),
+    leave: jest.fn(),
+    on: jest.fn((event, handler) => {
+      handlers[event] = handler;
+    }),
+    use: jest.fn(),
+  };
+};
+
+const setup = (rooms) => {
+  const namespace = {
+    adapter: {
+      allRooms: jest.fn().mockResolvedValue(new Set()),
+      sockets: jest.fn().mockResolvedValue(new Set()),
+    },
+    emit: jest.fn(),
+    in: jest.fn(() => ({ emit: jest.fn() })),
+    on: jest.fn(),
+    use: jest.fn(),
+  };
+  const io = { of: jest.fn().mockReturnValue(namespace) };
+  let connect;
+  namespace.on.mockImplementation((event, handler) => {
+    if (event === 'connection') {
+      connect = handler;
+    }
+  });
+  Room.find.mockImplementation(() => queryResult([]));
+  Room.findById.mockImplementation(({ _id }) => queryResult(rooms.get(String(_id))));
+  User.find.mockResolvedValue([]);
+  initRooms(io, []);
+
+  return async (socket) => {
+    await connect(socket);
+    return socket;
+  };
+};
+
+const joinRoom = async (socket, payload) => {
+  const acknowledgment = jest.fn();
+  await socket.handlers[Protocol.JOIN_ROOM](payload, acknowledgment);
+  return acknowledgment;
+};
+
+describe('private room namespace joins', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    metrics.beginRoomVisit.mockResolvedValue(undefined);
+    metrics.recordRoomJoinFailure.mockResolvedValue(undefined);
+  });
+
+  it('requires a valid password for a private room', async () => {
+    const room = makeRoom({
+      authenticate: jest.fn((password) => Promise.resolve(password === 'secret')),
+    });
+    const connect = setup(new Map([[room._id, room]]));
+    const socket = await connect(makeSocket({ id: 'private-socket', session: {} }));
+
+    const missingAcknowledgment = await joinRoom(socket, { id: room._id });
+    expect(room.authenticate).not.toHaveBeenCalled();
+    expect(missingAcknowledgment).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'password_required' }),
+      expect.objectContaining({ _id: room._id, private: true }),
+    );
+
+    const invalidAcknowledgment = await joinRoom(socket, {
+      id: room._id,
+      password: 'incorrect',
+    });
+    expect(invalidAcknowledgment).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'invalid_password' }),
+      expect.objectContaining({ _id: room._id, private: true }),
+    );
+
+    const validAcknowledgment = await joinRoom(socket, {
+      id: room._id,
+      password: 'secret',
+    });
+    expect(validAcknowledgment).toHaveBeenCalledWith(
+      null,
+      expect.objectContaining({ _id: room._id, accessCode: room.accessCode }),
+    );
+  });
+
+  it('accepts a duplicate join for the same room and rejects a different room', async () => {
+    const room = makeRoom();
+    const otherRoom = makeRoom({
+      _id: 'room-two',
+      accessCode: 'OTHER',
+      private: false,
+      password: null,
+    });
+    const connect = setup(new Map([
+      [room._id, room],
+      [otherRoom._id, otherRoom],
+    ]));
+    const socket = makeSocket({ id: 'joined-socket', session: {} });
+    socket.roomId = room._id;
+    socket.room = room;
+    await connect(socket);
+
+    const sameRoomAcknowledgment = await joinRoom(socket, { id: room._id });
+    expect(sameRoomAcknowledgment).toHaveBeenCalledWith(
+      null,
+      expect.objectContaining({ _id: room._id }),
+    );
+
+    const otherRoomAcknowledgment = await joinRoom(socket, { id: otherRoom._id });
+    expect(otherRoomAcknowledgment).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'already_in_room' }),
+      expect.objectContaining({ _id: otherRoom._id }),
+    );
+  });
+});
+
+describe('room namespace edits', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('acknowledges a successful edit with the updated room', async () => {
+    const room = makeRoom();
+    room.edit = jest.fn().mockImplementation(async () => {
+      room.password = 'bcrypt-hash-two';
+      return room;
+    });
+    const connect = setup(new Map([[room._id, room]]));
+    const socket = makeSocket({
+      id: 'admin-socket',
+      session: {},
+      userId: room.admin.id,
+    });
+    socket.room = room;
+    socket.roomId = room._id;
+    await connect(socket);
+    const acknowledgment = jest.fn();
+    const options = {
+      name: 'Renamed room',
+      private: true,
+      password: 'new-password',
+      type: 'normal',
+    };
+
+    await socket.handlers[Protocol.EDIT_ROOM](options, acknowledgment);
+
+    expect(room.edit).toHaveBeenCalledWith(options);
+    expect(acknowledgment).toHaveBeenCalledWith(
+      null,
+      expect.objectContaining({ _id: room._id, private: true }),
+    );
+  });
+
+  it('returns an edit failure through the acknowledgment', async () => {
+    const room = makeRoom();
+    const error = Object.assign(new Error('A password is required'), { statusCode: 400 });
+    room.edit = jest.fn().mockRejectedValue(error);
+    const connect = setup(new Map([[room._id, room]]));
+    const socket = makeSocket({
+      id: 'admin-socket',
+      session: {},
+      userId: room.admin.id,
+    });
+    socket.room = room;
+    socket.roomId = room._id;
+    await connect(socket);
+    const acknowledgment = jest.fn();
+
+    await socket.handlers[Protocol.EDIT_ROOM]({
+      name: 'Private room',
+      private: true,
+      type: 'normal',
+    }, acknowledgment);
+
+    expect(acknowledgment).toHaveBeenCalledWith(expect.objectContaining({
+      statusCode: 400,
+      event: Protocol.EDIT_ROOM,
+      message: 'A password is required',
+    }));
+  });
+});


### PR DESCRIPTION
## Summary

- preserve an in-progress solve and its pending result while the server restarts
- reconnect room sockets without duplicate joins and make same-room joins idempotent
- remember one successful private-room password per room on the device, reuse it after refresh or reconnect, and clear it when rejected or no longer needed
- show the private-room password form and inline error when automatic rejoin cannot restore access
- allow existing private rooms to be edited without replacing their password
- redact room passwords from socket logs

## Why

A deploy temporarily disconnects active racers. Timing can continue locally, but the client must rejoin the room before submitting the saved result. Private rooms were especially fragile after a refresh because the password existed only in Redux memory, and duplicate buffered joins could leave the client disconnected from the room even after Socket.IO recovered.

This keeps the solve local during the interruption, retries room access with the last successfully used password, and submits the result once the room join succeeds. If that password is no longer valid, it is removed and the normal password form is shown.

## Validation

- `yarn lint`
- `yarn test` — 75 client tests and 79 server tests passed
- `yarn build`
