### PR TITLE
Add WCA user anonymization tools

### DIFF
--- a/client/src/components/Admin/UserAnonymization.jsx
+++ b/client/src/components/Admin/UserAnonymization.jsx
@@ -1,0 +1,147 @@
+import React, { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { makeStyles } from '@material-ui/core/styles';
+import Button from '@material-ui/core/Button';
+import Card from '@material-ui/core/Card';
+import CardActions from '@material-ui/core/CardActions';
+import CardContent from '@material-ui/core/CardContent';
+import TextField from '@material-ui/core/TextField';
+import Typography from '@material-ui/core/Typography';
+import Alert from '@material-ui/lab/Alert';
+import { useConfirm } from 'material-ui-confirm';
+import { anonymizeAdminUser, searchAdminUsers } from '../../store/admin/actions';
+
+const useStyles = makeStyles(() => ({
+  form: {
+    display: 'flex',
+    gap: '1em',
+    marginBottom: '1em',
+  },
+  input: {
+    flexGrow: 1,
+  },
+  result: {
+    marginTop: '1em',
+  },
+}));
+
+const valueOrDash = (value) => value || '—';
+
+function UserAnonymization() {
+  const dispatch = useDispatch();
+  const confirm = useConfirm();
+  const classes = useStyles();
+  const [query, setQuery] = useState('');
+  const [users, setUsers] = useState([]);
+  const [searching, setSearching] = useState(false);
+  const [anonymizingId, setAnonymizingId] = useState(null);
+  const [message, setMessage] = useState(null);
+
+  const handleSearch = (event) => {
+    event.preventDefault();
+    setSearching(true);
+    setMessage(null);
+    dispatch(searchAdminUsers(query, (error, results = []) => {
+      setSearching(false);
+      if (error) {
+        setUsers([]);
+        setMessage({ severity: 'error', text: error.message });
+        return;
+      }
+      setUsers(results);
+      if (results.length === 0) {
+        setMessage({ severity: 'info', text: 'No matching users found.' });
+      }
+    }));
+  };
+
+  const handleAnonymize = (user) => {
+    confirm({
+      title: user.anonymizedAt
+        ? `Reapply the scrub for user ${user.id}?`
+        : `Anonymize user ${user.id}?`,
+      description: user.anonymizedAt
+        ? 'This retries the identity scrub in all configured data stores.'
+        : 'This permanently removes their name, username, email, WCA ID, avatar, and stored WCA token while retaining their history.',
+      confirmationText: user.anonymizedAt ? 'Reapply scrub' : 'Anonymize user',
+      cancellationText: 'Cancel',
+    }).then(() => {
+      setAnonymizingId(user.id);
+      setMessage(null);
+      dispatch(anonymizeAdminUser(user.id, (error, result) => {
+        setAnonymizingId(null);
+        if (error) {
+          setMessage({ severity: 'error', text: error.message });
+          return;
+        }
+        setUsers((currentUsers) => currentUsers.map((currentUser) => (
+          currentUser.id === user.id ? result.user : currentUser
+        )));
+        setMessage({
+          severity: result.postgresMirrorFailed ? 'warning' : 'success',
+          text: result.postgresMirrorFailed
+            ? `User ${user.id} was scrubbed from MongoDB, but the PostgreSQL scrub could not be confirmed. Reapply the scrub after PostgreSQL recovers.`
+            : (result.alreadyAnonymized
+              ? `User ${user.id} was already anonymized; its scrub was reapplied.`
+              : `User ${user.id} has been anonymized.`),
+        });
+      }));
+    }).catch(() => {});
+  };
+
+  return (
+    <section>
+      <Typography variant="h5" component="h2">Anonymize a user</Typography>
+      <Typography paragraph>
+        Search by internal ID, WCA ID, name, username, or email.
+      </Typography>
+      <form className={classes.form} onSubmit={handleSearch}>
+        <TextField
+          className={classes.input}
+          label="Find user"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          inputProps={{ 'aria-label': 'Find user' }}
+        />
+        <Button
+          type="submit"
+          variant="contained"
+          color="primary"
+          disabled={searching || query.trim().length < 2}
+        >
+          {searching ? 'Searching…' : 'Search'}
+        </Button>
+      </form>
+      {message && <Alert severity={message.severity}>{message.text}</Alert>}
+      {users.map((user) => (
+        <Card className={classes.result} key={user.id}>
+          <CardContent>
+            <Typography variant="h6">{`User ${user.id}`}</Typography>
+            <Typography>{`Name: ${valueOrDash(user.name)}`}</Typography>
+            <Typography>{`Username: ${valueOrDash(user.username)}`}</Typography>
+            <Typography>{`Email: ${valueOrDash(user.email)}`}</Typography>
+            <Typography>{`WCA ID: ${valueOrDash(user.wcaId)}`}</Typography>
+            <Typography>
+              {user.anonymizedAt
+                ? `Anonymized: ${new Date(user.anonymizedAt).toLocaleString()}`
+                : 'Not anonymized'}
+            </Typography>
+          </CardContent>
+          <CardActions>
+            <Button
+              color="secondary"
+              disabled={anonymizingId !== null}
+              onClick={() => handleAnonymize(user)}
+            >
+              {anonymizingId === user.id
+                ? 'Applying scrub…'
+                : (user.anonymizedAt ? 'Reapply scrub' : 'Anonymize')}
+            </Button>
+          </CardActions>
+        </Card>
+      ))}
+    </section>
+  );
+}
+
+export default UserAnonymization;

--- a/client/src/components/Admin/UserAnonymization.test.jsx
+++ b/client/src/components/Admin/UserAnonymization.test.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import {
+  act, fireEvent, render, screen,
+} from '@testing-library/react';
+import { useDispatch } from 'react-redux';
+import { useConfirm } from 'material-ui-confirm';
+import UserAnonymization from './UserAnonymization';
+import { ANONYMIZE_ADMIN_USER, SEARCH_ADMIN_USERS } from '../../store/admin/actions';
+
+jest.mock('react-redux', () => ({
+  useDispatch: jest.fn(),
+}));
+jest.mock('material-ui-confirm', () => ({
+  useConfirm: jest.fn(),
+}));
+
+describe('admin user anonymization', () => {
+  let dispatch;
+
+  beforeEach(() => {
+    dispatch = jest.fn();
+    useDispatch.mockReturnValue(dispatch);
+    useConfirm.mockReturnValue(jest.fn().mockResolvedValue(undefined));
+  });
+
+  it('searches and displays matching identity details', () => {
+    render(<UserAnonymization />);
+    fireEvent.change(screen.getByLabelText('Find user'), { target: { value: '2020TEST01' } });
+    fireEvent.click(screen.getByText('Search'));
+
+    const action = dispatch.mock.calls[0][0];
+    expect(action).toEqual(expect.objectContaining({
+      type: SEARCH_ADMIN_USERS,
+      query: '2020TEST01',
+    }));
+
+    act(() => action.onComplete(null, [{
+      id: 1234,
+      name: 'Test Solver',
+      username: 'solver',
+      email: 'solver@example.com',
+      wcaId: '2020TEST01',
+    }]));
+
+    expect(screen.getByText('Name: Test Solver')).toBeInTheDocument();
+    expect(screen.getByText('Email: solver@example.com')).toBeInTheDocument();
+  });
+
+  it('confirms before dispatching anonymization', async () => {
+    render(<UserAnonymization />);
+    fireEvent.change(screen.getByLabelText('Find user'), { target: { value: '1234' } });
+    fireEvent.click(screen.getByText('Search'));
+    act(() => dispatch.mock.calls[0][0].onComplete(null, [{
+      id: 1234,
+      name: 'Test Solver',
+    }]));
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Anonymize'));
+      await Promise.resolve();
+    });
+
+    expect(dispatch.mock.calls[1][0]).toEqual(expect.objectContaining({
+      type: ANONYMIZE_ADMIN_USER,
+      userId: 1234,
+    }));
+  });
+});

--- a/client/src/components/Admin/index.jsx
+++ b/client/src/components/Admin/index.jsx
@@ -5,8 +5,10 @@ import PropTypes from 'prop-types';
 import Container from '@material-ui/core/Container';
 import Paper from '@material-ui/core/Paper';
 import Button from '@material-ui/core/Button';
+import Typography from '@material-ui/core/Typography';
 import { fetchAdminData } from '../../store/admin/actions';
 import RoomCard from './RoomCard';
+import UserAnonymization from './UserAnonymization';
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -18,7 +20,7 @@ const useStyles = makeStyles(() => ({
   roomContainer: {
     overflow: 'auto',
     padding: '1em',
-    width: '50%',
+    width: '100%',
   },
   refetchButton: {
     margin: '1em',
@@ -36,6 +38,10 @@ function Admin({ rooms }) {
   return (
     <Paper className={classes.root}>
       <Container className={classes.roomContainer}>
+        <UserAnonymization />
+      </Container>
+      <Container className={classes.roomContainer}>
+        <Typography variant="h5" component="h2">Active rooms</Typography>
         <Button
           variant="contained"
           color="primary"
@@ -45,8 +51,6 @@ function Admin({ rooms }) {
         >
           Refetch Data
         </Button>
-      </Container>
-      <Container className={classes.roomContainer}>
         {rooms.length > 0 ? rooms.map((room) => (
           <RoomCard key={room.id} room={room} />
         )) : 'No rooms'}
@@ -60,7 +64,7 @@ Admin.propTypes = {
 };
 
 Admin.defaultProps = {
-  rooms: {},
+  rooms: [],
 };
 
 const mapStateToProps = (state) => ({

--- a/client/src/lib/protocol.json
+++ b/client/src/lib/protocol.json
@@ -46,5 +46,7 @@
   "START_ROOM": "start",
   "PAUSE_ROOM": "pause",
   "UPDATE_USER": "update_user",
-  "ADMIN": "admin"
+  "ADMIN": "admin",
+  "ADMIN_SEARCH_USERS": "admin_search_users",
+  "ADMIN_ANONYMIZE_USER": "admin_anonymize_user"
 }

--- a/client/src/store/admin/actions.js
+++ b/client/src/store/admin/actions.js
@@ -1,5 +1,7 @@
 export const FETCH_ADMIN_DATA = 'admin/fetch_admin_data';
 export const SET_ADMIN_DATA = 'admin/set_admin_data';
+export const SEARCH_ADMIN_USERS = 'admin/search_users';
+export const ANONYMIZE_ADMIN_USER = 'admin/anonymize_user';
 
 export const fetchAdminData = () => ({
   type: FETCH_ADMIN_DATA,
@@ -8,4 +10,16 @@ export const fetchAdminData = () => ({
 export const setAdminData = (data) => ({
   type: SET_ADMIN_DATA,
   data,
+});
+
+export const searchAdminUsers = (query, onComplete) => ({
+  type: SEARCH_ADMIN_USERS,
+  query,
+  onComplete,
+});
+
+export const anonymizeAdminUser = (userId, onComplete) => ({
+  type: ANONYMIZE_ADMIN_USER,
+  userId,
+  onComplete,
 });

--- a/client/src/store/middlewares/rooms.js
+++ b/client/src/store/middlewares/rooms.js
@@ -72,7 +72,9 @@ import { createMessage } from '../messages/actions';
 import { SEND_CHAT, receiveChat } from '../chat/actions';
 import { USER_CHANGED } from '../user/actions';
 import {
+  ANONYMIZE_ADMIN_USER,
   FETCH_ADMIN_DATA,
+  SEARCH_ADMIN_USERS,
   setAdminData,
 } from '../admin/actions';
 import { manager } from './manager';
@@ -815,6 +817,15 @@ export const createRoomsNamespaceMiddleware = ({
       namespace.emit(Protocol.ADMIN, (data) => {
         store.dispatch(setAdminData(data));
       });
+    },
+    [SEARCH_ADMIN_USERS]: ({ query, onComplete }) => {
+      namespace.emit(Protocol.ADMIN_SEARCH_USERS, { query }, onComplete);
+    },
+    [ANONYMIZE_ADMIN_USER]: ({ userId, onComplete }) => {
+      namespace.emit(Protocol.ADMIN_ANONYMIZE_USER, {
+        userId,
+        confirmation: `ANONYMIZE:${userId}`,
+      }, onComplete);
     },
   };
 

--- a/client/src/store/middlewares/rooms.test.js
+++ b/client/src/store/middlewares/rooms.test.js
@@ -12,6 +12,7 @@ import {
   submitResult,
 } from '../room/actions';
 import { connectSocket, createRoom } from '../rooms/actions';
+import { anonymizeAdminUser, searchAdminUsers } from '../admin/actions';
 import {
   PENDING_RESULT_STORAGE_KEY,
   createPendingResult,
@@ -173,6 +174,24 @@ describe('rooms middleware', () => {
     expect(emissionsFor(namespace, Protocol.JOIN_ROOM)).toHaveLength(1);
     expect(store.getState().room.fetching).toBe(false);
     expect(store.getState().room.attempts).toBe(attempts);
+  });
+
+  it('emits administrator user search and confirmed anonymization requests', () => {
+    const { namespace, store } = buildStore();
+    const searchComplete = jest.fn();
+    const anonymizeComplete = jest.fn();
+
+    store.dispatch(searchAdminUsers('2020TEST01', searchComplete));
+    store.dispatch(anonymizeAdminUser(1234, anonymizeComplete));
+
+    expect(emissionsFor(namespace, Protocol.ADMIN_SEARCH_USERS)[0].args).toEqual([
+      { query: '2020TEST01' },
+      searchComplete,
+    ]);
+    expect(emissionsFor(namespace, Protocol.ADMIN_ANONYMIZE_USER)[0].args).toEqual([
+      { userId: 1234, confirmation: 'ANONYMIZE:1234' },
+      anonymizeComplete,
+    ]);
   });
 
   it('waits for the socket connection before emitting the initial room join', () => {

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,3 +7,7 @@ Letscube is a progressive webapp that lets users race against eachother solving 
 The frontend is built with React, Material-UI, and Redux.
 
 The backend is built with NodeJS, Express and MongoDB, and they are both connected with socket.io.
+
+Operational guides:
+
+- [User anonymization](user-anonymization.md)

--- a/docs/user-anonymization.md
+++ b/docs/user-anonymization.md
@@ -1,0 +1,44 @@
+# User anonymization
+
+The admin page can permanently scrub a user's stored identity while retaining
+their internal ID, room history, and solve history. Search for the account,
+verify the displayed identifiers, and confirm the anonymization action. A later
+WCA login does not restore identity data on an anonymized account.
+
+If the admin page warns that the PostgreSQL scrub could not be confirmed, fix
+the PostgreSQL connection and use **Reapply scrub** on the anonymized account.
+The operation is idempotent and does not restore any removed data.
+
+## WCA profile audit
+
+The audit command is read-only. It checks users with stored WCA IDs against the
+configured WCA origin and writes a private CSV containing only profiles that
+returned HTTP 404. Network failures, rate limits, and other HTTP statuses are
+printed as errors and are never treated as candidates.
+
+Run the production audit inside the API container so it uses the deployed
+MongoDB and WCA configuration. From the production repository root:
+
+```sh
+DOCKER_CONTEXT=default docker compose \
+  -f compose.yml -f compose.prod.yml --env-file .env.prod \
+  exec -T api node server/scripts/auditAnonymizedWcaUsers.js \
+  --output /tmp/wca-anonymization-candidates.csv
+
+DOCKER_CONTEXT=default docker compose \
+  -f compose.yml -f compose.prod.yml --env-file .env.prod \
+  cp api:/tmp/wca-anonymization-candidates.csv \
+  ./wca-anonymization-candidates.csv
+
+chmod 600 ./wca-anonymization-candidates.csv
+```
+
+Before reviewing the report, verify that the command printed
+`https://www.worldcubeassociation.org` as its WCA origin. A successful audit
+with any inconclusive lookup errors exits with status 2 after still writing the
+candidate CSV, so inspect the printed error list separately.
+
+The report includes internal ID, WCA ID, name, username, lookup status, and
+reason; it excludes email and access tokens. Review every candidate manually in
+the admin page before anonymizing the account. Set `WCA_AUDIT_DELAY_MS` only
+when a different delay between requests is needed.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "start:client": "yarn workspace letscube-client start",
     "start:server": "yarn workspace letscube-server start:server",
     "start:socket": "yarn workspace letscube-server start:socket",
+    "audit:wca-anonymization": "yarn workspace letscube-server audit:wca-anonymization",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run"
   },

--- a/server/auth/index.js
+++ b/server/auth/index.js
@@ -3,6 +3,7 @@ const CustomStrategy = require('passport-custom').Strategy;
 const { URLSearchParams } = require('url');
 const { User } = require('../models');
 const metrics = require('../metrics');
+const { persistWcaProfile } = require('../services/wcaAuthentication');
 
 const checkStatus = async (res) => {
   if (res.ok) { // res.status >= 200 && res.status < 300
@@ -86,23 +87,11 @@ module.exports = (app, passport) => {
       }
 
       const profile = meRes.me;
-
-      User.findOneAndUpdate({
-        id: +profile.id,
-      }, {
-        id: +profile.id,
-        name: profile.name,
-        email: profile.email,
-        wcaId: profile.wca_id,
+      const user = await persistWcaProfile({
+        profile,
         accessToken: tokenRes.access_token,
-        avatar: profile.avatar,
-      }, {
-        upsert: true,
-        useFindAndModify: false,
-        new: true,
-      }, (err, user) => {
-        done(err, user.toObject());
       });
+      done(null, user.toObject());
     } catch (e) {
       done(e);
     }

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -4,6 +4,8 @@ const { mirrorUser } = require('../postgres/dualWrite');
 const redactUser = (doc, ret) => {
   delete ret.email;
   delete ret.accessToken;
+  delete ret.anonymizedAt;
+  delete ret.anonymizedBy;
   if (!doc.showWCAID) {
     delete ret.wcaId;
     if (!doc.preferRealName) {
@@ -51,10 +53,15 @@ const schema = new mongoose.Schema({
   },
   accessToken: {
     type: String,
-    required: true,
   },
   avatar: {
     type: Object,
+  },
+  anonymizedAt: {
+    type: Date,
+  },
+  anonymizedBy: {
+    type: Number,
   },
   muteTimer: {
     type: Boolean,
@@ -74,6 +81,9 @@ const schema = new mongoose.Schema({
 });
 
 schema.virtual('displayName').get(function () {
+  if (this.anonymizedAt) {
+    return this.username || 'Anonymous User';
+  }
   return !this.preferRealName ? this.username : this.name;
 });
 

--- a/server/package.json
+++ b/server/package.json
@@ -38,6 +38,7 @@
     "postgres:migrate:status": "prisma migrate status --config prisma.config.mjs",
     "postgres:schema:check": "prisma migrate diff --exit-code --from-config-datasource --to-schema prisma/schema.prisma --config prisma.config.mjs",
     "postgres:schema:validate": "prisma validate --config prisma.config.mjs",
+    "audit:wca-anonymization": "node scripts/auditAnonymizedWcaUsers.js",
     "test": "jest --passWithNoTests",
     "test:ci": "yarn test"
   },

--- a/server/postgres/dualWrite.js
+++ b/server/postgres/dualWrite.js
@@ -61,15 +61,36 @@ const upsertUser = async (client, user, fallbackUpdatedAt = new Date()) => {
   await client.query(`
     INSERT INTO app.users (
       id, wca_user_id, email, name, username, wca_id, preferences, avatar,
-      source_created_at, source_updated_at
-    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+      anonymized_at, anonymized_by_wca_user_id, source_created_at, source_updated_at
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
     ON CONFLICT (wca_user_id) DO UPDATE SET
-      email = EXCLUDED.email,
-      name = EXCLUDED.name,
-      username = EXCLUDED.username,
-      wca_id = EXCLUDED.wca_id,
-      preferences = EXCLUDED.preferences,
-      avatar = EXCLUDED.avatar,
+      email = CASE
+        WHEN app.users.anonymized_at IS NOT NULL OR EXCLUDED.anonymized_at IS NOT NULL
+          THEN NULL ELSE EXCLUDED.email END,
+      name = CASE
+        WHEN app.users.anonymized_at IS NOT NULL OR EXCLUDED.anonymized_at IS NOT NULL
+          THEN 'Anonymous User' ELSE EXCLUDED.name END,
+      username = CASE
+        WHEN app.users.anonymized_at IS NOT NULL OR EXCLUDED.anonymized_at IS NOT NULL
+          THEN CASE WHEN EXCLUDED.anonymized_at IS NOT NULL
+            THEN EXCLUDED.username ELSE app.users.username END
+        ELSE EXCLUDED.username END,
+      wca_id = CASE
+        WHEN app.users.anonymized_at IS NOT NULL OR EXCLUDED.anonymized_at IS NOT NULL
+          THEN NULL ELSE EXCLUDED.wca_id END,
+      preferences = CASE
+        WHEN EXCLUDED.anonymized_at IS NOT NULL
+          THEN EXCLUDED.preferences || '{"showWCAID": false, "preferRealName": false}'::jsonb
+        WHEN app.users.anonymized_at IS NOT NULL THEN app.users.preferences
+        ELSE EXCLUDED.preferences END,
+      avatar = CASE
+        WHEN app.users.anonymized_at IS NOT NULL OR EXCLUDED.anonymized_at IS NOT NULL
+          THEN '{}'::jsonb ELSE EXCLUDED.avatar END,
+      anonymized_at = COALESCE(app.users.anonymized_at, EXCLUDED.anonymized_at),
+      anonymized_by_wca_user_id = COALESCE(
+        app.users.anonymized_by_wca_user_id,
+        EXCLUDED.anonymized_by_wca_user_id
+      ),
       source_updated_at = EXCLUDED.source_updated_at,
       ingested_at = now()
     WHERE app.users.source_updated_at < EXCLUDED.source_updated_at
@@ -81,14 +102,18 @@ const upsertUser = async (client, user, fallbackUpdatedAt = new Date()) => {
           app.users.username,
           app.users.wca_id,
           app.users.preferences,
-          app.users.avatar
+          app.users.avatar,
+          app.users.anonymized_at,
+          app.users.anonymized_by_wca_user_id
         ) IS DISTINCT FROM ROW(
           EXCLUDED.email,
           EXCLUDED.name,
           EXCLUDED.username,
           EXCLUDED.wca_id,
           EXCLUDED.preferences,
-          EXCLUDED.avatar
+          EXCLUDED.avatar,
+          EXCLUDED.anonymized_at,
+          EXCLUDED.anonymized_by_wca_user_id
         )
       )
   `, [
@@ -106,6 +131,8 @@ const upsertUser = async (client, user, fallbackUpdatedAt = new Date()) => {
       muteTimer: !!user.muteTimer,
     },
     user.avatar || {},
+    user.anonymizedAt || null,
+    numericUserId(user.anonymizedBy),
     user.createdAt || null,
     updatedAt,
   ]);

--- a/server/postgres/dualWrite.test.js
+++ b/server/postgres/dualWrite.test.js
@@ -56,6 +56,25 @@ describe('PostgreSQL dual writer', () => {
     expect(values).not.toContain('must-not-be-mirrored');
   });
 
+  it('preserves an anonymization scrub against later stale user snapshots', async () => {
+    await mirrorUser({
+      ...user,
+      name: 'Anonymous User',
+      email: undefined,
+      username: undefined,
+      wcaId: undefined,
+      avatar: {},
+      anonymizedAt: new Date('2026-07-12T12:00:00.000Z'),
+      anonymizedBy: 8184,
+    });
+
+    const [statement, values] = client.query.mock.calls[0];
+    expect(statement).toContain('app.users.anonymized_at IS NOT NULL');
+    expect(statement).toContain('COALESCE(app.users.anonymized_at, EXCLUDED.anonymized_at)');
+    expect(values).toContain(8184);
+    expect(values).not.toContain('solver@example.com');
+  });
+
   it('mirrors a room snapshot, participants, attempts, and solves', async () => {
     const updatedAt = new Date('2026-07-09T20:00:00.000Z');
     const room = {

--- a/server/prisma/migrations/20260712000000_add_user_anonymization/migration.sql
+++ b/server/prisma/migrations/20260712000000_add_user_anonymization/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE app.users
+  ADD COLUMN anonymized_at timestamptz,
+  ADD COLUMN anonymized_by_wca_user_id bigint;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -12,6 +12,8 @@ model User {
   wcaId              String?           @map("wca_id")
   preferences        Json              @default("{}") @db.JsonB
   avatar             Json              @default("{}") @db.JsonB
+  anonymizedAt       DateTime?         @map("anonymized_at") @db.Timestamptz(6)
+  anonymizedByWcaUserId BigInt?         @map("anonymized_by_wca_user_id")
   sourceCreatedAt    DateTime?         @map("source_created_at") @db.Timestamptz(6)
   sourceUpdatedAt    DateTime          @map("source_updated_at") @db.Timestamptz(6)
   ingestedAt         DateTime          @default(now()) @map("ingested_at") @db.Timestamptz(6)

--- a/server/scripts/auditAnonymizedWcaUsers.js
+++ b/server/scripts/auditAnonymizedWcaUsers.js
@@ -1,0 +1,88 @@
+/* eslint-disable no-console */
+const fs = require('fs');
+const path = require('path');
+const mongoose = require('mongoose');
+
+const config = require('../runtimeConfig');
+const { connect } = require('../database');
+const { User } = require('../models');
+const {
+  DEFAULT_DELAY_MS,
+  auditWcaUsers,
+  candidatesToCsv,
+} = require('../services/wcaAnonymizationAudit');
+
+const argumentValue = (name) => {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? undefined : process.argv[index + 1];
+};
+
+const reportFilename = () => {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  return `wca-anonymization-candidates-${timestamp}.csv`;
+};
+
+const main = async () => {
+  const configuredOutput = argumentValue('--output');
+  if (process.argv.includes('--output') && !configuredOutput) {
+    throw new Error('--output requires a file path');
+  }
+  const outputPath = path.resolve(configuredOutput || reportFilename());
+  const configuredDelay = Number(process.env.WCA_AUDIT_DELAY_MS);
+  const delayMs = Number.isFinite(configuredDelay) && configuredDelay >= 0
+    ? configuredDelay : DEFAULT_DELAY_MS;
+
+  console.log(`WCA origin: ${config.wcaSource}`);
+  console.log('This audit is read-only; only HTTP 404 responses become candidates.');
+
+  await connect();
+  try {
+    const users = await User.find({
+      wcaId: { $exists: true, $nin: [null, ''] },
+      anonymizedAt: { $exists: false },
+    })
+      .select('id wcaId name username')
+      .sort({ id: 1 })
+      .lean();
+
+    const skipped = await User.countDocuments({
+      $or: [
+        { wcaId: { $exists: false } },
+        { wcaId: null },
+        { wcaId: '' },
+        { anonymizedAt: { $exists: true } },
+      ],
+    });
+
+    const result = await auditWcaUsers({
+      users,
+      wcaSource: config.wcaSource.replace(/\/$/, ''),
+      delayMs,
+    });
+    fs.writeFileSync(outputPath, candidatesToCsv(result.candidates), {
+      flag: 'wx',
+      mode: 0o600,
+    });
+
+    result.errors.forEach((error) => {
+      console.error(`Lookup error for ${error.internalId} (${error.wcaId}): ${error.reason}`);
+    });
+    console.log(`Checked: ${result.checked}`);
+    console.log(`Profiles present: ${result.present}`);
+    console.log(`Candidates: ${result.candidates.length}`);
+    console.log(`Skipped: ${skipped}`);
+    console.log(`Errors: ${result.errors.length}`);
+    console.log(`Candidate CSV: ${outputPath}`);
+
+    if (result.errors.length > 0) {
+      process.exitCode = 2;
+    }
+  } finally {
+    await mongoose.disconnect();
+  }
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/server/services/userAnonymization.js
+++ b/server/services/userAnonymization.js
@@ -1,0 +1,41 @@
+const config = require('../runtimeConfig');
+const { mirrorUser } = require('../postgres/dualWrite');
+
+const ANONYMOUS_NAME = 'Anonymous User';
+
+const publicAdminUser = (user) => ({
+  id: user.id,
+  name: user.name,
+  username: user.username,
+  email: user.email,
+  wcaId: user.wcaId,
+  anonymizedAt: user.anonymizedAt,
+});
+
+const anonymizeUser = async (user, administratorId, now = new Date()) => {
+  if (user.anonymizedAt) {
+    const postgresMirrorFailed = config.postgres.enabled && await mirrorUser(user) === null;
+    return { alreadyAnonymized: true, postgresMirrorFailed, user };
+  }
+
+  user.name = ANONYMOUS_NAME;
+  user.username = undefined;
+  user.email = undefined;
+  user.wcaId = undefined;
+  user.accessToken = undefined;
+  user.avatar = {};
+  user.showWCAID = false;
+  user.preferRealName = false;
+  user.anonymizedAt = now;
+  user.anonymizedBy = administratorId;
+
+  const savedUser = await user.save();
+  const postgresMirrorFailed = config.postgres.enabled && await mirrorUser(savedUser) === null;
+  return { alreadyAnonymized: false, postgresMirrorFailed, user: savedUser };
+};
+
+module.exports = {
+  ANONYMOUS_NAME,
+  anonymizeUser,
+  publicAdminUser,
+};

--- a/server/services/userAnonymization.test.js
+++ b/server/services/userAnonymization.test.js
@@ -1,0 +1,85 @@
+/* eslint-env jest */
+
+jest.mock('../runtimeConfig', () => ({ postgres: { enabled: true } }));
+jest.mock('../postgres/dualWrite', () => ({ mirrorUser: jest.fn() }));
+
+const { mirrorUser } = require('../postgres/dualWrite');
+
+const {
+  ANONYMOUS_NAME,
+  anonymizeUser,
+  publicAdminUser,
+} = require('./userAnonymization');
+
+describe('user anonymization', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mirrorUser.mockResolvedValue('postgres-user-id');
+  });
+
+  it('removes stored identity while retaining the internal ID', async () => {
+    const anonymizedAt = new Date('2026-07-12T12:00:00.000Z');
+    const user = {
+      id: 1234,
+      name: 'Named User',
+      username: 'solver',
+      email: 'solver@example.com',
+      wcaId: '2020TEST01',
+      accessToken: 'secret',
+      avatar: { url: 'avatar.png' },
+      showWCAID: true,
+      preferRealName: true,
+      save: jest.fn(function save() { return Promise.resolve(this); }),
+    };
+
+    const result = await anonymizeUser(user, 8184, anonymizedAt);
+
+    expect(result.alreadyAnonymized).toBe(false);
+    expect(result.postgresMirrorFailed).toBe(false);
+    expect(user).toEqual(expect.objectContaining({
+      id: 1234,
+      name: ANONYMOUS_NAME,
+      avatar: {},
+      showWCAID: false,
+      preferRealName: false,
+      anonymizedAt,
+      anonymizedBy: 8184,
+    }));
+    expect(user.username).toBeUndefined();
+    expect(user.email).toBeUndefined();
+    expect(user.wcaId).toBeUndefined();
+    expect(user.accessToken).toBeUndefined();
+    expect(user.save).toHaveBeenCalledTimes(1);
+    expect(mirrorUser).toHaveBeenCalledWith(user);
+  });
+
+  it('is idempotent and does not expose an access token to the admin client', async () => {
+    const user = {
+      id: 1234,
+      name: ANONYMOUS_NAME,
+      anonymizedAt: new Date('2026-07-12T12:00:00.000Z'),
+      accessToken: 'should-not-be-returned',
+      save: jest.fn(),
+    };
+
+    const result = await anonymizeUser(user, 8184);
+
+    expect(result.alreadyAnonymized).toBe(true);
+    expect(user.save).not.toHaveBeenCalled();
+    expect(mirrorUser).toHaveBeenCalledWith(user);
+    expect(publicAdminUser(user)).not.toHaveProperty('accessToken');
+  });
+
+  it('reports an unconfirmed PostgreSQL scrub so it can be reapplied', async () => {
+    const user = {
+      id: 1234,
+      name: ANONYMOUS_NAME,
+      anonymizedAt: new Date('2026-07-12T12:00:00.000Z'),
+    };
+    mirrorUser.mockResolvedValue(null);
+
+    const result = await anonymizeUser(user, 8184);
+
+    expect(result.postgresMirrorFailed).toBe(true);
+  });
+});

--- a/server/services/wcaAnonymizationAudit.js
+++ b/server/services/wcaAnonymizationAudit.js
@@ -1,0 +1,94 @@
+const DEFAULT_DELAY_MS = 250;
+
+const delay = (milliseconds) => new Promise((resolve) => {
+  setTimeout(resolve, milliseconds);
+});
+
+const auditWcaUsers = async ({
+  users,
+  wcaSource,
+  fetchProfile = fetch,
+  delayMs = DEFAULT_DELAY_MS,
+  wait = delay,
+}) => {
+  const candidates = [];
+  const errors = [];
+  let present = 0;
+
+  for (let index = 0; index < users.length; index += 1) {
+    const user = users[index];
+    const url = `${wcaSource}/persons/${encodeURIComponent(user.wcaId)}`;
+
+    try {
+      // Only a definite not-found response is a candidate. Outages and rate
+      // limits are inconclusive and must remain errors for manual follow-up.
+      // eslint-disable-next-line no-await-in-loop
+      const response = await fetchProfile(url, {
+        method: 'HEAD',
+        headers: { Accept: 'text/html' },
+      });
+      if (response && response.ok) {
+        present += 1;
+      } else if (response && response.status === 404) {
+        candidates.push({
+          internalId: user.id,
+          wcaId: user.wcaId,
+          name: user.name,
+          username: user.username,
+          lookupStatus: 404,
+          reason: 'WCA profile not found',
+        });
+      } else {
+        errors.push({
+          internalId: user.id,
+          wcaId: user.wcaId,
+          status: response && response.status,
+          reason: response ? `Unexpected HTTP ${response.status}` : 'No response',
+        });
+      }
+    } catch (error) {
+      errors.push({
+        internalId: user.id,
+        wcaId: user.wcaId,
+        reason: error.message || 'Network error',
+      });
+    }
+
+    if (delayMs > 0 && index < users.length - 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await wait(delayMs);
+    }
+  }
+
+  return {
+    checked: users.length,
+    present,
+    candidates,
+    errors,
+  };
+};
+
+const csvValue = (value) => {
+  if (value === undefined || value === null) {
+    return '';
+  }
+  let stringValue = String(value);
+  if (/^[=+\-@]/.test(stringValue)) {
+    stringValue = `'${stringValue}`;
+  }
+  return `"${stringValue.replace(/"/g, '""')}"`;
+};
+
+const candidatesToCsv = (candidates) => {
+  const columns = ['internalId', 'wcaId', 'name', 'username', 'lookupStatus', 'reason'];
+  const rows = candidates.map((candidate) => (
+    columns.map((column) => csvValue(candidate[column])).join(',')
+  ));
+  return `${columns.join(',')}\n${rows.length ? `${rows.join('\n')}\n` : ''}`;
+};
+
+module.exports = {
+  DEFAULT_DELAY_MS,
+  auditWcaUsers,
+  candidatesToCsv,
+};

--- a/server/services/wcaAnonymizationAudit.test.js
+++ b/server/services/wcaAnonymizationAudit.test.js
@@ -1,0 +1,67 @@
+/* eslint-env jest */
+
+const { auditWcaUsers, candidatesToCsv } = require('./wcaAnonymizationAudit');
+
+const users = [
+  {
+    id: 1, wcaId: '2020PRES01', name: 'Present', username: 'present',
+  },
+  {
+    id: 2, wcaId: '2020MISS01', name: 'Missing, User', username: '=formula',
+  },
+  {
+    id: 3, wcaId: '2020RATE01', name: 'Rate Limited', username: 'rate',
+  },
+  {
+    id: 4, wcaId: '2020ERRR01', name: 'Network Error', username: 'error',
+  },
+];
+
+describe('WCA anonymization audit', () => {
+  it('classifies only 404 responses as candidates', async () => {
+    const fetchProfile = jest.fn()
+      .mockResolvedValueOnce({ ok: true, status: 200 })
+      .mockResolvedValueOnce({ ok: false, status: 404 })
+      .mockResolvedValueOnce({ ok: false, status: 429 })
+      .mockRejectedValueOnce(new Error('socket closed'));
+    const wait = jest.fn().mockResolvedValue(undefined);
+
+    const result = await auditWcaUsers({
+      users,
+      wcaSource: 'https://www.worldcubeassociation.org',
+      fetchProfile,
+      delayMs: 10,
+      wait,
+    });
+
+    expect(result.present).toBe(1);
+    expect(result.candidates).toEqual([
+      expect.objectContaining({ internalId: 2, lookupStatus: 404 }),
+    ]);
+    expect(result.errors).toEqual([
+      expect.objectContaining({ internalId: 3, status: 429 }),
+      expect.objectContaining({ internalId: 4, reason: 'socket closed' }),
+    ]);
+    expect(fetchProfile).toHaveBeenNthCalledWith(
+      1,
+      'https://www.worldcubeassociation.org/persons/2020PRES01',
+      { method: 'HEAD', headers: { Accept: 'text/html' } },
+    );
+    expect(wait).toHaveBeenCalledTimes(3);
+  });
+
+  it('writes a safe candidate-only CSV', () => {
+    const csv = candidatesToCsv([{
+      internalId: 2,
+      wcaId: '2020MISS01',
+      name: 'Missing, "User"',
+      username: '=formula',
+      lookupStatus: 404,
+      reason: 'WCA profile not found',
+    }]);
+
+    expect(csv).toContain('"Missing, ""User"""');
+    expect(csv).toContain('"\'=formula"');
+    expect(csv).not.toContain('email');
+  });
+});

--- a/server/services/wcaAuthentication.js
+++ b/server/services/wcaAuthentication.js
@@ -1,0 +1,28 @@
+const { User } = require('../models');
+
+const persistWcaProfile = async ({ profile, accessToken }) => {
+  const id = +profile.id;
+  const existingUser = await User.findOne({ id });
+  if (existingUser && existingUser.anonymizedAt) {
+    return existingUser;
+  }
+
+  const filter = existingUser
+    ? { id, anonymizedAt: { $exists: false } }
+    : { id };
+  const user = await User.findOneAndUpdate(filter, {
+    id,
+    name: profile.name,
+    email: profile.email,
+    wcaId: profile.wca_id,
+    accessToken,
+    avatar: profile.avatar,
+  }, {
+    upsert: !existingUser,
+    useFindAndModify: false,
+    new: true,
+  });
+  return user || User.findOne({ id });
+};
+
+module.exports = { persistWcaProfile };

--- a/server/services/wcaAuthentication.test.js
+++ b/server/services/wcaAuthentication.test.js
@@ -1,0 +1,67 @@
+/* eslint-env jest */
+
+jest.mock('../models', () => ({
+  User: {
+    findOne: jest.fn(),
+    findOneAndUpdate: jest.fn(),
+  },
+}));
+
+const { User } = require('../models');
+const { persistWcaProfile } = require('./wcaAuthentication');
+
+const profile = {
+  id: 1234,
+  name: 'Named User',
+  email: 'solver@example.com',
+  wca_id: '2020TEST01',
+  avatar: { url: 'avatar.png' },
+};
+
+describe('WCA profile persistence', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('updates a normal account from its WCA profile', async () => {
+    const updatedUser = { id: 1234 };
+    User.findOne.mockResolvedValue(null);
+    User.findOneAndUpdate.mockResolvedValue(updatedUser);
+
+    await expect(persistWcaProfile({ profile, accessToken: 'secret' }))
+      .resolves.toBe(updatedUser);
+    expect(User.findOneAndUpdate).toHaveBeenCalledWith(
+      { id: 1234 },
+      expect.objectContaining({
+        name: profile.name,
+        email: profile.email,
+        wcaId: profile.wca_id,
+        accessToken: 'secret',
+      }),
+      expect.objectContaining({ upsert: true, new: true }),
+    );
+  });
+
+  it('does not restore identity or retain a token for an anonymized account', async () => {
+    const anonymizedUser = { id: 1234, anonymizedAt: new Date() };
+    User.findOne.mockResolvedValue(anonymizedUser);
+
+    await expect(persistWcaProfile({ profile, accessToken: 'new-secret' }))
+      .resolves.toBe(anonymizedUser);
+    expect(User.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('does not win a race with concurrent anonymization', async () => {
+    const normalUser = { id: 1234 };
+    const anonymizedUser = { id: 1234, anonymizedAt: new Date() };
+    User.findOne
+      .mockResolvedValueOnce(normalUser)
+      .mockResolvedValueOnce(anonymizedUser);
+    User.findOneAndUpdate.mockResolvedValue(null);
+
+    await expect(persistWcaProfile({ profile, accessToken: 'new-secret' }))
+      .resolves.toBe(anonymizedUser);
+    expect(User.findOneAndUpdate.mock.calls[0][0]).toEqual({
+      id: 1234,
+      anonymizedAt: { $exists: false },
+    });
+  });
+});

--- a/server/socket/lib/roomAuthorization.js
+++ b/server/socket/lib/roomAuthorization.js
@@ -26,6 +26,7 @@ const canAccessRoom = (userId, room) => {
 };
 
 module.exports = {
+  SUPER_ADMIN_ID,
   canAccessRoom,
   canDeleteRoom,
 };

--- a/server/socket/namespaces/rooms.js
+++ b/server/socket/namespaces/rooms.js
@@ -8,9 +8,14 @@ const logger = require('../../logger');
 const metrics = require('../../metrics');
 const { markRoomDeleted } = require('../../postgres/dualWrite');
 const { Room, User } = require('../../models');
-const { encodeUserRoom } = require('../utils');
+const { anonymizeUser, publicAdminUser } = require('../../services/userAnonymization');
+const { encodeUser, encodeUserRoom } = require('../utils');
 const roomMap = require('../lib/roomMap');
-const { canAccessRoom, canDeleteRoom } = require('../lib/roomAuthorization');
+const {
+  SUPER_ADMIN_ID,
+  canAccessRoom,
+  canDeleteRoom,
+} = require('../lib/roomAuthorization');
 const { isRoomTypeEnabled: checkRoomTypeEnabled } = require('../lib/roomAvailability');
 const { removeUserFromRoomSockets } = require('../lib/roomSockets');
 const { createReconnectGrace } = require('../lib/reconnectGrace');
@@ -24,6 +29,7 @@ const {
 } = require('../lib/socketHandler');
 
 const PASSWORD_SALT_ROUNDS = 10;
+const ADMIN_USER_SEARCH_LIMIT = 20;
 
 const publicRoomKeys = ['_id', 'name', 'event', 'usersLength', 'private', 'type', 'owner', 'requireRevealedIdentity', 'startTime', 'started', 'twitchChannel'];
 const privateRoomKeys = [...publicRoomKeys, 'users', 'competing', 'waitingFor', 'banned', 'attempts', 'admin', 'accessCode', 'inRoom', 'registered', 'nextSolveAt'];
@@ -53,6 +59,23 @@ const getRooms = (userId) => Room.find().populate('users').populate('admin').pop
   )).map(roomMask));
 
 const roomTimerObj = {};
+
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const adminUserSearchFilter = (query) => {
+  const pattern = new RegExp(escapeRegExp(query), 'i');
+  const filters = [
+    { wcaId: pattern },
+    { name: pattern },
+    { username: pattern },
+    { email: pattern },
+  ];
+  const numericId = Number(query);
+  if (Number.isSafeInteger(numericId) && numericId > 0) {
+    filters.unshift({ id: numericId });
+  }
+  return { $or: filters };
+};
 
 module.exports = (io, middlewares) => {
   const ns = () => io.of('/rooms');
@@ -112,6 +135,17 @@ module.exports = (io, middlewares) => {
     if (isRoomTypeEnabled(room.type)) {
       ns().emit(Protocol.GLOBAL_ROOM_UPDATED, roomMask(room));
     }
+  }
+
+  async function refreshRoomsForUser(user) {
+    const rooms = await Room.find({ users: user._id })
+      .populate('users')
+      .populate('admin')
+      .populate('owner');
+    rooms.forEach((room) => {
+      ns().in(room.accessCode).emit(Protocol.UPDATE_ROOM, joinRoomMask(room));
+      sendGlobalRoomUpdate(room);
+    });
   }
 
   async function finalizeUserDeparture({
@@ -1115,13 +1149,69 @@ module.exports = (io, middlewares) => {
     });
 
     on(Protocol.ADMIN, (cb) => {
-      if (!socket.userId || +socket.userId !== 8184) {
+      if (!socket.userId || +socket.userId !== SUPER_ADMIN_ID) {
         return;
       }
 
       roomMap(ns).then((sockets) => {
         cb(sockets);
       });
+    });
+
+    on(Protocol.ADMIN_SEARCH_USERS, async (payload = {}, acknowledgment) => {
+      const acknowledge = optionalAcknowledgment(acknowledgment);
+      if (!socket.userId || +socket.userId !== SUPER_ADMIN_ID) {
+        acknowledge({ statusCode: 403, message: 'Administrator access required' });
+        return;
+      }
+
+      const query = typeof payload.query === 'string' ? payload.query.trim() : '';
+      if (query.length < 2) {
+        acknowledge({ statusCode: 400, message: 'Enter at least two characters' });
+        return;
+      }
+
+      const users = await User.find(adminUserSearchFilter(query))
+        .select('id name username email wcaId anonymizedAt')
+        .sort({ id: 1 })
+        .limit(ADMIN_USER_SEARCH_LIMIT);
+      acknowledge(null, users.map(publicAdminUser));
+    });
+
+    on(Protocol.ADMIN_ANONYMIZE_USER, async (payload = {}, acknowledgment) => {
+      const acknowledge = optionalAcknowledgment(acknowledgment);
+      if (!socket.userId || +socket.userId !== SUPER_ADMIN_ID) {
+        acknowledge({ statusCode: 403, message: 'Administrator access required' });
+        return;
+      }
+
+      const userId = Number(payload.userId);
+      if (!Number.isSafeInteger(userId) || userId <= 0
+        || payload.confirmation !== `ANONYMIZE:${userId}`) {
+        acknowledge({ statusCode: 400, message: 'Invalid anonymization confirmation' });
+        return;
+      }
+
+      const user = await User.findOne({ id: userId });
+      if (!user) {
+        acknowledge({ statusCode: 404, message: 'User not found' });
+        return;
+      }
+
+      const result = await anonymizeUser(user, +socket.userId);
+      acknowledge(null, {
+        alreadyAnonymized: result.alreadyAnonymized,
+        postgresMirrorFailed: result.postgresMirrorFailed,
+        user: publicAdminUser(result.user),
+      });
+
+      if (!result.alreadyAnonymized) {
+        ns().in(encodeUser(userId)).disconnectSockets(true);
+        await Promise.all([
+          refreshRoomsForUser(user),
+          updateClientsWithUsers(),
+        ]).catch((error) => logger.error(error));
+      }
     });
   });
 };

--- a/server/socket/namespaces/rooms.test.js
+++ b/server/socket/namespaces/rooms.test.js
@@ -7,6 +7,7 @@ const initRooms = require('./rooms');
 
 jest.mock('../../runtimeConfig', () => ({
   grandPrix: { enabled: false },
+  postgres: { enabled: false },
   socketio: { reconnectGraceMs: 60000 },
 }));
 jest.mock('../../logger', () => ({
@@ -27,10 +28,12 @@ jest.mock('../../models', () => ({
   },
   User: {
     find: jest.fn(),
+    findOne: jest.fn(),
   },
 }));
 jest.mock('../../postgres/dualWrite', () => ({
   markRoomDeleted: jest.fn(),
+  mirrorUser: jest.fn(),
 }));
 jest.mock('../lib/reconnectGrace', () => ({
   createReconnectGrace: jest.fn(() => ({
@@ -103,13 +106,17 @@ const makeSocket = ({
 };
 
 const setup = (rooms) => {
+  const roomOperator = {
+    disconnectSockets: jest.fn(),
+    emit: jest.fn(),
+  };
   const namespace = {
     adapter: {
       allRooms: jest.fn().mockResolvedValue(new Set()),
       sockets: jest.fn().mockResolvedValue(new Set()),
     },
     emit: jest.fn(),
-    in: jest.fn(() => ({ emit: jest.fn() })),
+    in: jest.fn(() => roomOperator),
     on: jest.fn(),
     use: jest.fn(),
   };
@@ -125,10 +132,12 @@ const setup = (rooms) => {
   User.find.mockResolvedValue([]);
   initRooms(io, []);
 
-  return async (socket) => {
+  const connectSocket = async (socket) => {
     await connect(socket);
     return socket;
   };
+  connectSocket.roomOperator = roomOperator;
+  return connectSocket;
 };
 
 const joinRoom = async (socket, payload) => {
@@ -205,6 +214,108 @@ describe('private room namespace joins', () => {
       expect.objectContaining({ reason: 'already_in_room' }),
       expect.objectContaining({ _id: otherRoom._id }),
     );
+  });
+});
+
+describe('administrator user anonymization', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects user searches from non-administrators', async () => {
+    const connect = setup(new Map());
+    const socket = await connect(makeSocket({ id: 'user-socket', session: {} }));
+    const acknowledgment = jest.fn();
+
+    await socket.handlers[Protocol.ADMIN_SEARCH_USERS]({ query: 'solver' }, acknowledgment);
+
+    expect(acknowledgment).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
+  });
+
+  it('searches users with a safe admin projection', async () => {
+    const connect = setup(new Map());
+    const socket = await connect(makeSocket({
+      id: 'admin-socket',
+      session: {},
+      userId: 8184,
+    }));
+    const users = [{
+      id: 1234,
+      name: 'Test Solver',
+      username: 'solver',
+      email: 'solver@example.com',
+      wcaId: '2020TEST01',
+      accessToken: 'secret',
+    }];
+    const query = {
+      limit: jest.fn().mockResolvedValue(users),
+      select: jest.fn(),
+      sort: jest.fn(),
+    };
+    query.select.mockReturnValue(query);
+    query.sort.mockReturnValue(query);
+    User.find.mockImplementation((filter) => (
+      filter.$or ? query : Promise.resolve([])
+    ));
+    const acknowledgment = jest.fn();
+
+    await socket.handlers[Protocol.ADMIN_SEARCH_USERS]({ query: 'solver' }, acknowledgment);
+
+    expect(query.select).toHaveBeenCalledWith('id name username email wcaId anonymizedAt');
+    expect(acknowledgment).toHaveBeenCalledWith(null, [expect.objectContaining({ id: 1234 })]);
+    expect(acknowledgment.mock.calls[0][1][0]).not.toHaveProperty('accessToken');
+  });
+
+  it('requires exact confirmation, scrubs the user, and disconnects active sessions', async () => {
+    const connect = setup(new Map());
+    const socket = await connect(makeSocket({
+      id: 'admin-socket',
+      session: {},
+      userId: 8184,
+    }));
+    const user = {
+      id: 1234,
+      name: 'Test Solver',
+      username: 'solver',
+      email: 'solver@example.com',
+      wcaId: '2020TEST01',
+      accessToken: 'secret',
+      avatar: { url: 'avatar.png' },
+      showWCAID: true,
+      preferRealName: true,
+      save: jest.fn(function save() { return Promise.resolve(this); }),
+    };
+    User.findOne.mockResolvedValue(user);
+    const invalidAcknowledgment = jest.fn();
+
+    await socket.handlers[Protocol.ADMIN_ANONYMIZE_USER]({
+      userId: 1234,
+      confirmation: 'wrong',
+    }, invalidAcknowledgment);
+    expect(invalidAcknowledgment).toHaveBeenCalledWith(
+      expect.objectContaining({ statusCode: 400 }),
+    );
+    expect(user.save).not.toHaveBeenCalled();
+
+    const acknowledgment = jest.fn();
+    await socket.handlers[Protocol.ADMIN_ANONYMIZE_USER]({
+      userId: 1234,
+      confirmation: 'ANONYMIZE:1234',
+    }, acknowledgment);
+
+    expect(user).toEqual(expect.objectContaining({
+      id: 1234,
+      name: 'Anonymous User',
+      showWCAID: false,
+      preferRealName: false,
+      anonymizedBy: 8184,
+    }));
+    expect(user.email).toBeUndefined();
+    expect(user.wcaId).toBeUndefined();
+    expect(acknowledgment).toHaveBeenCalledWith(null, expect.objectContaining({
+      alreadyAnonymized: false,
+    }));
+    expect(connect.roomOperator.disconnectSockets).toHaveBeenCalledWith(true);
   });
 });
 


### PR DESCRIPTION
## Summary

- add an administrator-only user search and confirmation flow that scrubs names, usernames, email addresses, WCA IDs, avatars, and stored OAuth tokens while preserving internal IDs and historical results
- mirror anonymization state into PostgreSQL, protect the scrub from stale snapshots, disconnect active sessions, refresh affected rooms, and prevent later WCA login from restoring removed identity data
- add a read-only WCA profile audit that classifies only HTTP 404 profile pages as candidates, writes a private CSV, and reports network or provider failures separately
- document the production Docker workflow for running the audit and manually reviewing candidates

## Why

Let's Cube needs to honor WCA anonymization requests without deleting competition history or accidentally restoring removed identity data during OAuth login or PostgreSQL dual writes. The audit provides a conservative one-time way to identify likely affected accounts for manual review.

## Validation

- server: 92 tests across 18 suites
- client: 85 tests across 15 suites
- client ESLint
- changed server files ESLint
- client production build
- Prisma schema validation
- `git diff --check`
- verified the WCA public profile endpoint returns 200 for a public person and 404 for an unknown profile

Full server lint still reports the pre-existing `import/extensions` failure in `server/api.js:5`; this PR does not change that file.