### PR TITLE
Harden public user discovery

### DIFF
--- a/client/src/components/Friends.jsx
+++ b/client/src/components/Friends.jsx
@@ -1,5 +1,5 @@
 import React, {
-  useCallback, useEffect, useState,
+  useCallback, useEffect, useRef, useState,
 } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
@@ -22,6 +22,7 @@ import TextField from '@material-ui/core/TextField';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import { lcFetch } from '../lib/fetch';
+import createRequestSequence from '../lib/requestSequence';
 import { createRoom } from '../store/rooms/actions';
 
 const useStyles = makeStyles((theme) => ({
@@ -137,19 +138,29 @@ function AddFriendDialog({ onClose, onRequest, open }) {
   const [results, setResults] = useState([]);
   const [error, setError] = useState(null);
   const [searching, setSearching] = useState(false);
+  const searchRequests = useRef(createRequestSequence());
+
+  useEffect(() => () => searchRequests.current.invalidate(), []);
 
   const search = (event) => {
     event.preventDefault();
     setError(null);
     setSearching(true);
-    lcFetch(`/api/users/search?q=${encodeURIComponent(query)}`)
+    const request = searchRequests.current.start();
+    lcFetch(`/api/users/search?q=${encodeURIComponent(query)}`, { signal: request.signal })
       .then(async (response) => {
         if (!response.ok) throw new Error(await errorMessage(response, 'Unable to search for cubers'));
         return response.json();
       })
-      .then((data) => setResults(data.results || []))
-      .catch((searchError) => setError(searchError.message))
-      .finally(() => setSearching(false));
+      .then((data) => {
+        if (request.isCurrent()) setResults(data.results || []);
+      })
+      .catch((searchError) => {
+        if (request.isCurrent() && searchError.name !== 'AbortError') setError(searchError.message);
+      })
+      .finally(() => {
+        if (request.isCurrent()) setSearching(false);
+      });
   };
 
   const requestFriend = (user) => {

--- a/client/src/components/User.jsx
+++ b/client/src/components/User.jsx
@@ -34,6 +34,7 @@ const useStyles = makeStyles((theme) => ({
 function User({ user, admin, className }) {
   const classes = useStyles();
   const [anchorEl, setAnchorEl] = React.useState(null);
+  const profileKey = user.profileKey;
 
   const handlePopoverOpen = (event) => {
     setAnchorEl(event.currentTarget);
@@ -56,8 +57,8 @@ function User({ user, admin, className }) {
         aria-haspopup="true"
         onMouseEnter={handlePopoverOpen}
         onMouseLeave={handlePopoverClose}
-        component={user.id ? Link : 'span'}
-        to={user.id ? `/users/${user.id}` : undefined}
+        component={profileKey ? Link : 'span'}
+        to={profileKey ? `/users/${profileKey}` : undefined}
         variant="subtitle2"
       >
         {user.displayName}
@@ -113,6 +114,7 @@ User.propTypes = {
     username: PropTypes.string,
     wcaId: PropTypes.string,
     name: PropTypes.string,
+    profileKey: PropTypes.string,
     showWCAID: PropTypes.bool,
   }).isRequired,
   admin: PropTypes.bool,

--- a/client/src/components/User.test.jsx
+++ b/client/src/components/User.test.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Typography from '@material-ui/core/Typography';
+import User from './User';
+
+describe('User', () => {
+  const baseUser = { displayName: 'Cuber', id: 42 };
+
+  it('does not turn an internal user ID into a public profile link', () => {
+    const wrapper = shallow(<User user={baseUser} />);
+    const name = wrapper.find(Typography).first();
+
+    expect(name.prop('component')).toBe('span');
+    expect(name.prop('to')).toBeUndefined();
+  });
+
+  it('links only through a server-provided public profile key', () => {
+    const wrapper = shallow(<User user={{ ...baseUser, profileKey: 'cuber' }} />);
+    const name = wrapper.find(Typography).first();
+
+    expect(name.prop('to')).toBe('/users/cuber');
+  });
+});

--- a/client/src/lib/requestSequence.js
+++ b/client/src/lib/requestSequence.js
@@ -1,0 +1,25 @@
+const createRequestSequence = () => {
+  let controller = null;
+  let sequence = 0;
+
+  const invalidate = () => {
+    sequence += 1;
+    if (controller) controller.abort();
+    controller = null;
+  };
+
+  return {
+    invalidate,
+    start() {
+      invalidate();
+      const requestId = sequence;
+      controller = new AbortController();
+      return {
+        isCurrent: () => requestId === sequence,
+        signal: controller.signal,
+      };
+    },
+  };
+};
+
+export default createRequestSequence;

--- a/client/src/lib/requestSequence.test.js
+++ b/client/src/lib/requestSequence.test.js
@@ -1,0 +1,24 @@
+import createRequestSequence from './requestSequence';
+
+describe('request sequence', () => {
+  it('aborts and invalidates a previous request before starting another', () => {
+    const requests = createRequestSequence();
+    const first = requests.start();
+    const second = requests.start();
+
+    expect(first.signal.aborted).toBe(true);
+    expect(first.isCurrent()).toBe(false);
+    expect(second.signal.aborted).toBe(false);
+    expect(second.isCurrent()).toBe(true);
+  });
+
+  it('invalidates an in-flight request when it is no longer needed', () => {
+    const requests = createRequestSequence();
+    const request = requests.start();
+
+    requests.invalidate();
+
+    expect(request.signal.aborted).toBe(true);
+    expect(request.isCurrent()).toBe(false);
+  });
+});

--- a/server/index.js
+++ b/server/index.js
@@ -13,6 +13,7 @@ const session = require('./middlewares/session');
 const logger = require('./logger');
 const auth = require('./auth');
 const api = require('./api');
+const { isUserApiRequest } = require('./requestLogging');
 
 Error.stackTraceLimit = 100;
 
@@ -49,14 +50,13 @@ const init = async () => {
 
   /* Logging */
 
-  const isDiscoverySearch = (req) => req.path === '/api/users/search';
   app.use(morgan('combined', {
-    skip: (req, res) => res.statusCode >= 400 || isDiscoverySearch(req),
+    skip: (req, res) => res.statusCode >= 400 || isUserApiRequest(req),
     stream: { write: (message) => logger.info(message) },
   }));
 
   app.use(morgan('combined', {
-    skip: (req, res) => res.statusCode < 400 || isDiscoverySearch(req),
+    skip: (req, res) => res.statusCode < 400 || isUserApiRequest(req),
     stream: { write: (message) => logger.error(message) },
   }));
 

--- a/server/requestLogging.js
+++ b/server/requestLogging.js
@@ -1,0 +1,3 @@
+const isUserApiRequest = (req) => /^\/api\/users(?:\/|$)/.test(req.path);
+
+module.exports = { isUserApiRequest };

--- a/server/requestLogging.test.js
+++ b/server/requestLogging.test.js
@@ -1,0 +1,15 @@
+/* eslint-env jest */
+
+const { isUserApiRequest } = require('./requestLogging');
+
+describe('request logging privacy', () => {
+  it('suppresses every users API route, including paths containing email-like input', () => {
+    expect(isUserApiRequest({ path: '/api/users/search' })).toBe(true);
+    expect(isUserApiRequest({ path: '/api/users/name%40example.com' })).toBe(true);
+    expect(isUserApiRequest({ path: '/api/users/visible-cuber' })).toBe(true);
+  });
+
+  it('does not suppress unrelated API requests', () => {
+    expect(isUserApiRequest({ path: '/api/friends' })).toBe(false);
+  });
+});

--- a/server/social/discoveryService.js
+++ b/server/social/discoveryService.js
@@ -127,15 +127,14 @@ const createDiscoveryService = ({
     if (cursor) {
       conditions.push({ id: { $gt: cursor.id } });
     }
-    const users = await lean(userModel.find({ $and: conditions })
-      .sort({ id: 1 }).limit(limit + 1));
     const blocked = await blockedIds(viewerId);
+    const users = await lean(userModel.find({ $and: conditions })
+      .sort({ id: 1 }).limit(limit + blocked.size + 1));
     const visible = users.filter((user) => !blocked.has(user.id));
     const page = visible.slice(0, limit).map((user) => publicUserProjection(user));
-    const hasMore = users.length > limit;
     return {
-      nextCursor: hasMore && page.length
-        ? encodeCursor(users[limit - 1])
+      nextCursor: visible.length > limit && page.length
+        ? encodeCursor(visible[limit - 1])
         : null,
       results: page,
     };

--- a/server/social/discoveryService.test.js
+++ b/server/social/discoveryService.test.js
@@ -16,7 +16,7 @@ jest.mock('./relationshipState', () => ({
   },
 }));
 
-const { createDiscoveryService } = require('./discoveryService');
+const { createDiscoveryService, decodeCursor } = require('./discoveryService');
 
 const chain = (value) => ({
   lean: jest.fn().mockResolvedValue(value),
@@ -33,9 +33,9 @@ const users = [
   },
 ];
 
-const createService = ({ blocks = [], relationships = [] } = {}) => {
+const createService = ({ blocks = [], relationships = [], searchUsers = users } = {}) => {
   const userModel = {
-    find: jest.fn(() => chain(users)),
+    find: jest.fn(() => chain(searchUsers)),
     findOne: jest.fn((query) => Promise.resolve(users.find((user) => (
       (query.usernameNormalized && user.usernameNormalized === query.usernameNormalized)
       || (query.showWCAID && user.showWCAID && user.wcaId === query.wcaId)
@@ -104,6 +104,21 @@ describe('privacy-safe discovery', () => {
       results: [expect.objectContaining({ id: 3 })],
     });
     await expect(service.publicProfile({ id: 1 }, 'cuber')).resolves.toBeNull();
+  });
+
+  it('fills a page after filtering blocked users and advances from the last visible user', async () => {
+    const { service, userModel } = createService({
+      blocks: [{ blockerId: 1, blockedId: 2, active: true }],
+      searchUsers: [...users, {
+        id: 4, name: 'Another Name', username: 'CuberThree', usernameNormalized: 'cuberthree', showWCAID: false,
+      }],
+    });
+
+    const result = await service.search({ id: 1 }, 'cuber', 1);
+
+    expect(result.results).toEqual([expect.objectContaining({ id: 3 })]);
+    expect(decodeCursor(result.nextCursor)).toEqual({ id: 3 });
+    expect(userModel.find.mock.results[0].value.limit).toHaveBeenCalledWith(3);
   });
 
   it('returns viewer-relative safe actions and no editable/private fields', async () => {


### PR DESCRIPTION
## Summary

- suppress request logging for every `/api/users/*` route so email-like path input cannot reach access logs
- paginate discovery after applying block visibility and advance cursors from the last visible result
- restrict profile navigation to explicit public profile keys and abort/supersede stale discovery searches

## Why

Discovery must never reveal or retain private email-like input, and user-facing links must not expose internal numeric identifiers. Rapid searches and block filtering also need stable, privacy-safe results.

## Validation

- `yarn workspace letscube-server lint`
- `yarn workspace letscube-client lint`
- `yarn workspace letscube-server test --runInBand social/discoveryService.test.js requestLogging.test.js`
- `yarn workspace letscube-client test --watchAll=false --runInBand requestSequence.test.js User.test.jsx`
- `git diff --check`