### PR TITLE
Fix Cypress social feature socket configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
         run: LETSCUBE_TEST_AUTH=true SOCIAL_FEATURES_ENABLED=true yarn workspace letscube-server node index.js > server.log 2>&1 &
 
       - name: Start socket server
-        run: yarn workspace letscube-server node socket/ > socket.log 2>&1 &
+        run: SOCIAL_FEATURES_ENABLED=true yarn workspace letscube-server node socket/ > socket.log 2>&1 &
 
       - name: Wait for local stack
         run: |


### PR DESCRIPTION
## Summary
- start the CI Socket.IO process with `SOCIAL_FEATURES_ENABLED=true`
- align it with the API process so the race-invitation Cypress flow can create its room

## Validation
- `git diff --check origin/master...HEAD`
- parsed `.github/workflows/ci.yml` and asserted the socket step enables the social feature flag

The existing full-stack Cypress race-invitation test provides regression coverage.