### PR TITLE
Run CodeQL on dev pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Validate CI branch coverage
         run: scripts/test-ci-branches.sh
 
+      - name: Validate CodeQL branch coverage
+        run: scripts/test-codeql-branches.sh
+
   server:
     name: Server lint and unit tests
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches:
+      - dev
       - master
   schedule:
     - cron: '23 10 * * 1'

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -9,7 +9,7 @@ Production deployment remains a separately authorized operation described in
 1. Open each focused feature pull request against `dev`.
 2. Review and merge the feature into `dev`.
 3. Treat the resulting `dev` merge commit as the release candidate. Its push
-   CI run must finish before promotion is considered.
+   CI and CodeQL push runs must finish before promotion is considered.
 4. Open a reviewed promotion from that exact `dev` commit to `master`.
 5. After the promotion is merged and its `master` push CI passes, perform the
    separately authorized deployment procedure.
@@ -22,8 +22,8 @@ on `dev` after release-candidate validation requires a new validation run.
 Before approving a `dev` to `master` promotion, record or link the following in
 the promotion pull request:
 
-- the exact `dev` commit SHA and its successful CI run, including Cypress for
-  full-stack changes;
+- the exact `dev` commit SHA and its successful CI and CodeQL push runs,
+  including Cypress for full-stack changes;
 - the review that approved the promotion and any issue or milestone links;
 - focused and broad checks relevant to the change, including checks not run;
 - schema migration compatibility and data-backfill evidence when persistence

--- a/scripts/test-codeql-branches.sh
+++ b/scripts/test-codeql-branches.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+WORKFLOW="$SCRIPT_DIR/../.github/workflows/codeql.yml"
+
+for branch in dev master; do
+  if ! awk '
+    /^  push:/ { in_push = 1; next }
+    in_push && /^  [^[:space:]]/ { exit }
+    in_push && $0 == "      - " branch { found = 1 }
+    END { exit !found }
+  ' branch="$branch" "$WORKFLOW"; then
+    echo "CodeQL must run on pushes to $branch." >&2
+    exit 1
+  fi
+done
+
+echo "CodeQL push branch coverage checks passed."


### PR DESCRIPTION
## Summary
- analyze pushes to the `dev` integration branch with CodeQL
- guard the CodeQL push branch list in CI
- require CodeQL evidence for release-candidate promotion

Closes #177

## Verification
- `scripts/test-codeql-branches.sh`
- `scripts/test-ci-branches.sh`
- YAML parsing for both workflow files
- `git diff --check`