### PR TITLE
Preserve historical PostgreSQL solves

### DIFF
--- a/server/models/room.js
+++ b/server/models/room.js
@@ -527,7 +527,9 @@ const collectPostgresChanges = (room) => {
   return {
     attempts,
     participantUserIds: [...participantUserIds],
-    replaceAttempts: !room.isNew && room.isModified('event'),
+    // An event switch starts a new attempt stream. The migration writer must
+    // mirror it without deleting attempts from the previous event.
+    syncAllAttempts: !room.isNew && room.isModified('event'),
     syncAllParticipants: room.isNew,
     syncRoomOwners: room.isNew || room.isModified('owner') || room.isModified('admin'),
   };

--- a/server/models/room.test.js
+++ b/server/models/room.test.js
@@ -407,13 +407,13 @@ describe('room security helpers', () => {
         syncAllResults: false,
       }],
       participantUserIds: ['1234'],
-      replaceAttempts: false,
+      syncAllAttempts: false,
       syncAllParticipants: false,
       syncRoomOwners: false,
     });
   });
 
-  it('replaces PostgreSQL attempts when the room event resets them', () => {
+  it('syncs the new PostgreSQL attempt stream when the room event resets it', () => {
     const room = RoomModel.hydrate({
       _id: '507f1f77bcf86cd799439011',
       name: 'Practice room',
@@ -439,7 +439,7 @@ describe('room security helpers', () => {
         syncAllResults: true,
       }],
       participantUserIds: [],
-      replaceAttempts: true,
+      syncAllAttempts: true,
       syncAllParticipants: false,
       syncRoomOwners: false,
     });

--- a/server/postgres/dualWrite.js
+++ b/server/postgres/dualWrite.js
@@ -537,7 +537,7 @@ const syncAttemptResults = async (client, roomState, attemptState, attempt, user
 
 const writeRoomChanges = async (client, room, changes) => {
   const resultUserIds = new Set();
-  if (changes.replaceAttempts) {
+  if (changes.syncAllAttempts) {
     (room.attempts || []).forEach((attempt) => {
       resultEntries(attempt.results).forEach(([userId]) => resultUserIds.add(userId));
     });
@@ -563,8 +563,7 @@ const writeRoomChanges = async (client, room, changes) => {
     return null;
   }
 
-  if (changes.replaceAttempts) {
-    await client.query('DELETE FROM app.attempts WHERE room_id = $1', [roomState.roomId]);
+  if (changes.syncAllAttempts) {
     for (const [attemptIndex, attempt] of (room.attempts || []).entries()) {
       const attemptState = await upsertAttempt(client, room, roomState, attempt, attemptIndex);
       await syncAttemptResults(

--- a/server/postgres/dualWrite.test.js
+++ b/server/postgres/dualWrite.test.js
@@ -175,6 +175,48 @@ describe('PostgreSQL dual writer', () => {
       .toContain(12001);
   });
 
+  it('retains prior-event rows when an event switch starts a new attempt stream', async () => {
+    const updatedAt = new Date('2026-07-10T20:00:00.000Z');
+    const room = {
+      _id: '507f1f77bcf86cd799439011',
+      name: 'Practice room',
+      event: '222',
+      accessCode: 'room-access-code',
+      type: 'normal',
+      owner: user,
+      admin: user,
+      users: [user],
+      attempts: [{
+        id: 0,
+        scrambles: ['R U2 R\''],
+        results: new Map([['1234', {
+          time: 8000,
+          penalties: {},
+          createdAt: updatedAt,
+          updatedAt,
+        }]]),
+        createdAt: updatedAt,
+        updatedAt,
+      }],
+      createdAt: updatedAt,
+      updatedAt,
+    };
+
+    await mirrorRoomChanges(room, {
+      attempts: [],
+      participantUserIds: [],
+      syncAllAttempts: true,
+      syncAllParticipants: false,
+      syncRoomOwners: true,
+    });
+
+    const statements = client.query.mock.calls.map(([sql]) => sql);
+    expect(statements.some((sql) => sql.includes('DELETE FROM app.attempts'))).toBe(false);
+    expect(statements.some((sql) => sql.includes('DELETE FROM app.solves'))).toBe(false);
+    expect(statements.filter((sql) => sql.includes('INSERT INTO app.attempts'))).toHaveLength(1);
+    expect(statements.filter((sql) => sql.includes('INSERT INTO app.solves'))).toHaveLength(1);
+  });
+
   it('mirrors sanitized metric events and soft-deletes rooms', async () => {
     const occurredAt = new Date('2026-07-09T20:00:00.000Z');
     await mirrorMetricEvent({


### PR DESCRIPTION
## Summary

- stop the PostgreSQL dual writer from deleting a room's prior attempts and solves when its event changes
- retain the complete collected history while upserting the new event's attempt stream
- cover the retention invariant in focused server tests

## Why

An event switch previously issued a room-wide attempt delete. Because solves cascade from attempts, this silently erased previously collected PostgreSQL solve history before the RaceSession migration.

## User impact

No user-visible feature is enabled. Background PostgreSQL collection now retains historic solve data needed for the Competition Rooms foundation.

## Validation

- yarn workspace v1.22.22
yarn run v1.22.22
$ jest --passWithNoTests --runInBand postgres/dualWrite.test.js models/room.test.js
Done in 0.68s.
Done in 0.81s.
- yarn workspace v1.22.22
yarn run v1.22.22
$ eslint ./

/tmp/letscube-preserve-history/server/features.test.js
  8:3  warning  Unused eslint-disable directive (no problems were reported from 'global-require')

/tmp/letscube-preserve-history/server/postgres/dualWrite.js
  1:1  warning  Unused eslint-disable directive (no problems were reported from 'no-await-in-loop', 'no-continue', or 'no-restricted-syntax')

/tmp/letscube-preserve-history/server/runtimeConfig.test.js
  3:1  warning  Unused eslint-disable directive (no problems were reported from 'global-require')

/tmp/letscube-preserve-history/server/social/relationshipService.js
  1:1  warning  Unused eslint-disable directive (no problems were reported from 'no-await-in-loop' or 'no-continue')

✖ 4 problems (0 errors, 4 warnings)
  0 errors and 4 warnings potentially fixable with the `--fix` option.

Done in 0.66s.
Done in 0.79s.
- commit hook: yarn run v1.22.22
$ turbo run test:ci

   • Packages in scope: letscube-client, letscube-scrambles, letscube-server
   • Running test:ci in 3 packages
   • Remote caching disabled, using shared worktree cache

letscube-scrambles:test:ci: cache hit, replaying logs 8a659104007abce5
letscube-server:test:ci: cache hit, replaying logs 99c5516b5e675549
letscube-server:test:ci: yarn run v1.22.22
letscube-server:test:ci: $ yarn test
letscube-server:test:ci: $ jest --passWithNoTests
letscube-server:test:ci: PASS ./health.test.js
letscube-server:test:ci: PASS ./username.test.js
letscube-server:test:ci: PASS socket/lib/reconnectGrace.test.js
letscube-server:test:ci: PASS ./usernamePostgresBackfill.test.js
letscube-server:test:ci: PASS socket/lib/roomAuthorization.test.js
letscube-scrambles:test:ci: yarn run v1.22.22
letscube-server:test:ci: PASS middlewares/csrf.test.js
letscube-scrambles:test:ci: $ yarn test
letscube-server:test:ci: PASS ./usernameBackfill.test.js
letscube-scrambles:test:ci: $ jest --passWithNoTests
letscube-server:test:ci: PASS privacy/userEmailPurge.test.js
letscube-scrambles:test:ci: PASS ./index.test.js
letscube-server:test:ci: PASS socket/lib/roomMap.test.js
letscube-scrambles:test:ci:   generateScramble
letscube-server:test:ci: PASS socket/lib/socketHandler.test.js
letscube-scrambles:test:ci:     ✓ uses cubing.js for 222 (11 ms)
letscube-server:test:ci: PASS ./runtimeConfig.test.js
letscube-scrambles:test:ci:     ✓ uses cubing.js for 333 (1 ms)
letscube-scrambles:test:ci:     ✓ uses cubing.js for 333bf (5 ms)
letscube-scrambles:test:ci:     ✓ uses cubing.js for 333oh (1 ms)
letscube-server:test:ci: PASS social/discoveryService.test.js
letscube-server:test:ci: PASS socket/namespaces/default.test.js
letscube-server:test:ci: PASS socket/middlewares/logger.test.js
letscube-server:test:ci: PASS ./database.test.js
letscube-server:test:ci: PASS realtime/socialEvents.test.js
letscube-scrambles:test:ci:     ✓ uses cubing.js for 333ft (6 ms)
letscube-scrambles:test:ci:     ✓ uses cubing.js for 444 (1 ms)
letscube-scrambles:test:ci:     ✓ uses cubing.js for 444bf (1 ms)
letscube-scrambles:test:ci:     ✓ uses cubing.js for 555 (6 ms)
letscube-server:test:ci: PASS auth/testUser.test.js
letscube-server:test:ci: PASS socket/lib/resultSubmission.test.js
letscube-server:test:ci: PASS ./features.test.js
letscube-server:test:ci: PASS auth/wcaProfile.test.js
letscube-scrambles:test:ci:     ✓ uses cubing.js for 555bf (1 ms)
letscube-scrambles:test:ci:     ✓ uses cubing.js for 666 (8 ms)
letscube-scrambles:test:ci:     ✓ uses cubing.js for 777 (1 ms)
letscube-scrambles:test:ci:     ✓ uses cubing.js for minx (17 ms)
letscube-scrambles:test:ci:     ✓ uses cubing.js for pyram (1 ms)
letscube-scrambles:test:ci:     ✓ uses cubing.js for clock (11 ms)
letscube-server:test:ci: PASS middlewares/apiRateLimit.test.js
letscube-server:test:ci: PASS socket/lib/roomSockets.test.js
letscube-server:test:ci: PASS ./requestLogging.test.js
letscube-server:test:ci: PASS models/user.test.js
letscube-server:test:ci: PASS socket/middlewares/wrapExpressMiddleware.test.js
letscube-scrambles:test:ci:     ✓ uses cubing.js for skewb (1 ms)
letscube-scrambles:test:ci:     ✓ uses cubing.js for sq1 (1 ms)
letscube-server:test:ci: PASS socket/lib/roomAvailability.test.js
letscube-server:test:ci: PASS socket/namespaces/rooms.test.js
letscube-server:test:ci: PASS postgres/dualWrite.test.js
letscube-scrambles:test:ci:     ✓ uses cubing.js for fto (18 ms)
letscube-scrambles:test:ci:     ✓ uses Scrambow for the custom practice events (7 ms)
letscube-server:test:ci: PASS social/requestRateLimiter.test.js
letscube-client:test:ci: cache hit, replaying logs d98a4f5d76a5613c
letscube-server:test:ci: PASS ./metrics.test.js
letscube-server:test:ci: PASS social/raceInvitationService.test.js
letscube-scrambles:test:ci:     ✓ rejects events that are not in the shared catalog (35 ms)
letscube-scrambles:test:ci:     ✓ surfaces cubing.js failures without using Scrambow (1 ms)
letscube-server:test:ci: PASS social/notificationService.test.js
letscube-server:test:ci: PASS models/friendRelationship.test.js
letscube-server:test:ci: PASS social/relationshipService.test.js
letscube-server:test:ci: PASS api/friends.test.js
letscube-scrambles:test:ci:   events
letscube-scrambles:test:ci:     ✓ contains every event supported by the generator (8 ms)
letscube-scrambles:test:ci:     ✓ does not expose provider implementation details (23 ms)
letscube-scrambles:test:ci: 
letscube-scrambles:test:ci: Test Suites: 1 passed, 1 total
letscube-client:test:ci: yarn run v1.22.22
letscube-client:test:ci: $ jest --ci --passWithNoTests
letscube-client:test:ci: PASS src/lib/stats.test.js
letscube-server:test:ci: PASS ./api.test.js
letscube-server:test:ci: PASS auth/index.test.js
letscube-server:test:ci: PASS models/room.test.js
letscube-server:test:ci: 
letscube-scrambles:test:ci: Tests:       22 passed, 22 total
letscube-scrambles:test:ci: Snapshots:   0 total
letscube-scrambles:test:ci: Time:        1.545 s
letscube-client:test:ci: PASS src/lib/utils.test.js
letscube-client:test:ci: PASS src/store/room/reducer.test.js
letscube-server:test:ci: Test Suites: 38 passed, 38 total
letscube-server:test:ci: Tests:       206 passed, 206 total
letscube-server:test:ci: Snapshots:   0 total
letscube-server:test:ci: Time:        1.892 s
letscube-scrambles:test:ci: Ran all test suites.
letscube-scrambles:test:ci: Done in 2.46s.
letscube-client:test:ci: PASS src/lib/requestSequence.test.js
letscube-client:test:ci: PASS src/lib/wcaAuth.test.js
letscube-client:test:ci: PASS src/lib/fetch.test.js
letscube-server:test:ci: Ran all test suites.
letscube-server:test:ci: Done in 2.26s.
letscube-client:test:ci: PASS src/components/Notifications/registry.test.js
letscube-client:test:ci: PASS src/store/notifications/reducer.test.js
letscube-client:test:ci: PASS src/store/room/roomPasswordStorage.test.js
letscube-client:test:ci: PASS src/components/common/Scramble.test.jsx
letscube-client:test:ci:   ● Console
letscube-client:test:ci: 
letscube-client:test:ci:     console.error
letscube-client:test:ci:       Warning: Scramble: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
letscube-client:test:ci:           at event (/tmp/letscube-codeql-fixture-security/client/src/components/common/Scramble.jsx:43:3)
letscube-client:test:ci:           at DefaultPropsProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/system/DefaultPropsProvider/DefaultPropsProvider.js:17:3)
letscube-client:test:ci:           at RtlProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/system/RtlProvider/index.js:15:3)
letscube-client:test:ci:           at ThemeProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/private-theming/node/ThemeProvider/ThemeProvider.js:40:5)
letscube-client:test:ci:           at ThemeProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/system/ThemeProvider/ThemeProvider.js:56:5)
letscube-client:test:ci:           at ThemeProviderNoVars (/tmp/letscube-codeql-fixture-security/node_modules/@mui/material/node/styles/ThemeProviderNoVars.js:15:10)
letscube-client:test:ci:           at ThemeProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/material/node/styles/ThemeProvider.js:16:3)
letscube-client:test:ci: 
letscube-client:test:ci:        7 | const theme = createTheme();
letscube-client:test:ci:        8 |
letscube-client:test:ci:     >  9 | const renderScramble = (props) => render(
letscube-client:test:ci:          |                                         ^
letscube-client:test:ci:       10 |   <ThemeProvider theme={theme}>
letscube-client:test:ci:       11 |     <Scramble {...props} />
letscube-client:test:ci:       12 |   </ThemeProvider>,
letscube-client:test:ci: 
letscube-client:test:ci:       at printWarning (../node_modules/react-dom/cjs/react-dom.development.js:86:30)
letscube-client:test:ci:       at error (../node_modules/react-dom/cjs/react-dom.development.js:60:7)
letscube-client:test:ci:       at validateFunctionComponentInDev (../node_modules/react-dom/cjs/react-dom.development.js:20230:9)
letscube-client:test:ci:       at mountIndeterminateComponent (../node_modules/react-dom/cjs/react-dom.development.js:20189:7)
letscube-client:test:ci:       at beginWork (../node_modules/react-dom/cjs/react-dom.development.js:21626:16)
letscube-client:test:ci:       at beginWork$1 (../node_modules/react-dom/cjs/react-dom.development.js:27465:14)
letscube-client:test:ci:       at performUnitOfWork (../node_modules/react-dom/cjs/react-dom.development.js:26599:12)
letscube-client:test:ci:       at workLoopSync (../node_modules/react-dom/cjs/react-dom.development.js:26505:5)
letscube-client:test:ci:       at renderRootSync (../node_modules/react-dom/cjs/react-dom.development.js:26473:7)
letscube-client:test:ci:       at performConcurrentWorkOnRoot (../node_modules/react-dom/cjs/react-dom.development.js:25777:74)
letscube-client:test:ci:       at flushActQueue (../node_modules/react/cjs/react.development.js:2667:24)
letscube-client:test:ci:       at act (../node_modules/react/cjs/react.development.js:2582:11)
letscube-client:test:ci:       at ../node_modules/@testing-library/react/dist/act-compat.js:46:25
letscube-client:test:ci:       at renderRoot (../node_modules/@testing-library/react/dist/pure.js:189:26)
letscube-client:test:ci:       at render (../node_modules/@testing-library/react/dist/pure.js:291:10)
letscube-client:test:ci:       at renderScramble (src/components/common/Scramble.test.jsx:9:41)
letscube-client:test:ci:       at Object.renderScramble (src/components/common/Scramble.test.jsx:16:3)
letscube-client:test:ci: 
letscube-client:test:ci: PASS src/components/Timer/ManualTimer.test.jsx
letscube-client:test:ci: PASS src/components/User.test.jsx
letscube-client:test:ci:   ● Console
letscube-client:test:ci: 
letscube-client:test:ci:     console.error
letscube-client:test:ci:       Warning: User: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
letscube-client:test:ci:           at user (/tmp/letscube-codeql-fixture-security/client/src/components/User.jsx:34:17)
letscube-client:test:ci:           at Router (/tmp/letscube-codeql-fixture-security/node_modules/react-router/cjs/react-router.js:283:30)
letscube-client:test:ci:           at MemoryRouter (/tmp/letscube-codeql-fixture-security/node_modules/react-router/cjs/react-router.js:385:35)
letscube-client:test:ci:           at DefaultPropsProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/system/DefaultPropsProvider/DefaultPropsProvider.js:17:3)
letscube-client:test:ci:           at RtlProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/system/RtlProvider/index.js:15:3)
letscube-client:test:ci:           at ThemeProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/private-theming/node/ThemeProvider/ThemeProvider.js:40:5)
letscube-client:test:ci:           at ThemeProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/system/ThemeProvider/ThemeProvider.js:56:5)
letscube-client:test:ci:           at ThemeProviderNoVars (/tmp/letscube-codeql-fixture-security/node_modules/@mui/material/node/styles/ThemeProviderNoVars.js:15:10)
letscube-client:test:ci:           at ThemeProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/material/node/styles/ThemeProvider.js:16:3)
letscube-client:test:ci:           at StyledEngineProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/styled-engine/node/StyledEngineProvider/StyledEngineProvider.js:106:5)
letscube-client:test:ci:           at children (/tmp/letscube-codeql-fixture-security/client/src/theme.jsx:77:33)
letscube-client:test:ci: 
letscube-client:test:ci:        8 |   const baseUser = { displayName: 'Cuber', id: 42 };
letscube-client:test:ci:        9 |
letscube-client:test:ci:     > 10 |   const renderUser = (user) => render(
letscube-client:test:ci:          |                                      ^
letscube-client:test:ci:       11 |     <ThemeProvider>
letscube-client:test:ci:       12 |       <MemoryRouter>
letscube-client:test:ci:       13 |         <User user={user} />
letscube-client:test:ci: 
letscube-client:test:ci:       at printWarning (../node_modules/react-dom/cjs/react-dom.development.js:86:30)
letscube-client:test:ci:       at error (../node_modules/react-dom/cjs/react-dom.development.js:60:7)
letscube-client:test:ci:       at validateFunctionComponentInDev (../node_modules/react-dom/cjs/react-dom.development.js:20230:9)
letscube-client:test:ci:       at mountIndeterminateComponent (../node_modules/react-dom/cjs/react-dom.development.js:20189:7)
letscube-client:test:ci:       at beginWork (../node_modules/react-dom/cjs/react-dom.development.js:21626:16)
letscube-client:test:ci:       at beginWork$1 (../node_modules/react-dom/cjs/react-dom.development.js:27465:14)
letscube-client:test:ci:       at performUnitOfWork (../node_modules/react-dom/cjs/react-dom.development.js:26599:12)
letscube-client:test:ci:       at workLoopSync (../node_modules/react-dom/cjs/react-dom.development.js:26505:5)
letscube-client:test:ci:       at renderRootSync (../node_modules/react-dom/cjs/react-dom.development.js:26473:7)
letscube-client:test:ci:       at performConcurrentWorkOnRoot (../node_modules/react-dom/cjs/react-dom.development.js:25777:74)
letscube-client:test:ci:       at flushActQueue (../node_modules/react/cjs/react.development.js:2667:24)
letscube-client:test:ci:       at act (../node_modules/react/cjs/react.development.js:2582:11)
letscube-client:test:ci:       at ../node_modules/@testing-library/react/dist/act-compat.js:46:25
letscube-client:test:ci:       at renderRoot (../node_modules/@testing-library/react/dist/pure.js:189:26)
letscube-client:test:ci:       at render (../node_modules/@testing-library/react/dist/pure.js:291:10)
letscube-client:test:ci:       at renderUser (src/components/User.test.jsx:10:38)
letscube-client:test:ci:       at Object.renderUser (src/components/User.test.jsx:19:5)
letscube-client:test:ci: 
letscube-client:test:ci: PASS src/components/Lobby/Announcements.test.jsx
letscube-client:test:ci:   ● Console
letscube-client:test:ci: 
letscube-client:test:ci:     console.error
letscube-client:test:ci:       Warning: ReactMarkdown: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
letscube-client:test:ci:           at ReactMarkdown (/tmp/letscube-codeql-fixture-security/node_modules/react-markdown/src/react-markdown.js:81:42)
letscube-client:test:ci:           at div
letscube-client:test:ci:           at /tmp/letscube-codeql-fixture-security/node_modules/@emotion/react/dist/emotion-element-25f9958c.browser.cjs.js:56:23
letscube-client:test:ci:           at Paper (/tmp/letscube-codeql-fixture-security/node_modules/@mui/material/node/Paper/Paper.js:75:59)
letscube-client:test:ci:           at useState (/tmp/letscube-codeql-fixture-security/client/src/components/Lobby/Announcements.jsx:16:51)
letscube-client:test:ci: 
letscube-client:test:ci:       at printWarning (../node_modules/react-dom/cjs/react-dom.development.js:86:30)
letscube-client:test:ci:       at error (../node_modules/react-dom/cjs/react-dom.development.js:60:7)
letscube-client:test:ci:       at validateFunctionComponentInDev (../node_modules/react-dom/cjs/react-dom.development.js:20230:9)
letscube-client:test:ci:       at mountIndeterminateComponent (../node_modules/react-dom/cjs/react-dom.development.js:20189:7)
letscube-client:test:ci:       at beginWork (../node_modules/react-dom/cjs/react-dom.development.js:21626:16)
letscube-client:test:ci:       at beginWork$1 (../node_modules/react-dom/cjs/react-dom.development.js:27465:14)
letscube-client:test:ci:       at performUnitOfWork (../node_modules/react-dom/cjs/react-dom.development.js:26599:12)
letscube-client:test:ci:       at workLoopSync (../node_modules/react-dom/cjs/react-dom.development.js:26505:5)
letscube-client:test:ci:       at renderRootSync (../node_modules/react-dom/cjs/react-dom.development.js:26473:7)
letscube-client:test:ci:       at performConcurrentWorkOnRoot (../node_modules/react-dom/cjs/react-dom.development.js:25777:74)
letscube-client:test:ci:       at workLoop (../node_modules/scheduler/cjs/scheduler.development.js:266:34)
letscube-client:test:ci:       at flushWork (../node_modules/scheduler/cjs/scheduler.development.js:239:14)
letscube-client:test:ci:       at performWorkUntilDeadline (../node_modules/scheduler/cjs/scheduler.development.js:533:21)
letscube-client:test:ci:       at Timeout.task [as _onTimeout] (../node_modules/jsdom/lib/jsdom/browser/Window.js:579:19)
letscube-client:test:ci: 
letscube-client:test:ci: PASS src/store/room/resultOutbox.test.js
letscube-client:test:ci: PASS src/components/common/ScramblePreview.test.jsx
letscube-client:test:ci:   ● Console
letscube-client:test:ci: 
letscube-client:test:ci:     console.error
letscube-client:test:ci:       Warning: ScramblePreview: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
letscube-client:test:ci:           at event (/tmp/letscube-codeql-fixture-security/client/src/components/common/ScramblePreview.jsx:103:28)
letscube-client:test:ci:           at DefaultPropsProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/system/DefaultPropsProvider/DefaultPropsProvider.js:17:3)
letscube-client:test:ci:           at RtlProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/system/RtlProvider/index.js:15:3)
letscube-client:test:ci:           at ThemeProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/private-theming/node/ThemeProvider/ThemeProvider.js:40:5)
letscube-client:test:ci:           at ThemeProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/system/ThemeProvider/ThemeProvider.js:56:5)
letscube-client:test:ci:           at ThemeProviderNoVars (/tmp/letscube-codeql-fixture-security/node_modules/@mui/material/node/styles/ThemeProviderNoVars.js:15:10)
letscube-client:test:ci:           at ThemeProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/material/node/styles/ThemeProvider.js:16:3)
letscube-client:test:ci:           at StyledEngineProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/styled-engine/node/StyledEngineProvider/StyledEngineProvider.js:106:5)
letscube-client:test:ci:           at children (/tmp/letscube-codeql-fixture-security/client/src/theme.jsx:77:33)
letscube-client:test:ci: 
letscube-client:test:ci:       13 | const players = [];
letscube-client:test:ci:       14 |
letscube-client:test:ci:     > 15 | const renderPreview = (element) => render(<ThemeProvider>{element}</ThemeProvider>);
letscube-client:test:ci:          |                                          ^
letscube-client:test:ci:       16 |
letscube-client:test:ci:       17 | const flushPlayerLoad = () => act(async () => {
letscube-client:test:ci:       18 |   await Promise.resolve();
letscube-client:test:ci: 
letscube-client:test:ci:       at printWarning (../node_modules/react-dom/cjs/react-dom.development.js:86:30)
letscube-client:test:ci:       at error (../node_modules/react-dom/cjs/react-dom.development.js:60:7)
letscube-client:test:ci:       at validateFunctionComponentInDev (../node_modules/react-dom/cjs/react-dom.development.js:20230:9)
letscube-client:test:ci:       at mountIndeterminateComponent (../node_modules/react-dom/cjs/react-dom.development.js:20189:7)
letscube-client:test:ci:       at beginWork (../node_modules/react-dom/cjs/react-dom.development.js:21626:16)
letscube-client:test:ci:       at beginWork$1 (../node_modules/react-dom/cjs/react-dom.development.js:27465:14)
letscube-client:test:ci:       at performUnitOfWork (../node_modules/react-dom/cjs/react-dom.development.js:26599:12)
letscube-client:test:ci:       at workLoopSync (../node_modules/react-dom/cjs/react-dom.development.js:26505:5)
letscube-client:test:ci:       at renderRootSync (../node_modules/react-dom/cjs/react-dom.development.js:26473:7)
letscube-client:test:ci:       at performConcurrentWorkOnRoot (../node_modules/react-dom/cjs/react-dom.development.js:25777:74)
letscube-client:test:ci:       at flushActQueue (../node_modules/react/cjs/react.development.js:2667:24)
letscube-client:test:ci:       at act (../node_modules/react/cjs/react.development.js:2582:11)
letscube-client:test:ci:       at ../node_modules/@testing-library/react/dist/act-compat.js:46:25
letscube-client:test:ci:       at renderRoot (../node_modules/@testing-library/react/dist/pure.js:189:26)
letscube-client:test:ci:       at render (../node_modules/@testing-library/react/dist/pure.js:291:10)
letscube-client:test:ci:       at renderPreview (src/components/common/ScramblePreview.test.jsx:15:42)
letscube-client:test:ci:       at Object.renderPreview (src/components/common/ScramblePreview.test.jsx:43:25)
letscube-client:test:ci: 
letscube-client:test:ci:     console.error
letscube-client:test:ci:       Warning: TwistyVisualization: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
letscube-client:test:ci:           at event (/tmp/letscube-codeql-fixture-security/client/src/components/common/ScramblePreview.jsx:33:32)
letscube-client:test:ci:           at div
letscube-client:test:ci:           at event (/tmp/letscube-codeql-fixture-security/client/src/components/common/ScramblePreview.jsx:103:28)
letscube-client:test:ci:           at DefaultPropsProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/system/DefaultPropsProvider/DefaultPropsProvider.js:17:3)
letscube-client:test:ci:           at RtlProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/system/RtlProvider/index.js:15:3)
letscube-client:test:ci:           at ThemeProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/private-theming/node/ThemeProvider/ThemeProvider.js:40:5)
letscube-client:test:ci:           at ThemeProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/system/ThemeProvider/ThemeProvider.js:56:5)
letscube-client:test:ci:           at ThemeProviderNoVars (/tmp/letscube-codeql-fixture-security/node_modules/@mui/material/node/styles/ThemeProviderNoVars.js:15:10)
letscube-client:test:ci:           at ThemeProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/material/node/styles/ThemeProvider.js:16:3)
letscube-client:test:ci:           at StyledEngineProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/styled-engine/node/StyledEngineProvider/StyledEngineProvider.js:106:5)
letscube-client:test:ci:           at children (/tmp/letscube-codeql-fixture-security/client/src/theme.jsx:77:33)
letscube-client:test:ci: 
letscube-client:test:ci:       13 | const players = [];
letscube-client:test:ci:       14 |
letscube-client:test:ci:     > 15 | const renderPreview = (element) => render(<ThemeProvider>{element}</ThemeProvider>);
letscube-client:test:ci:          |                                          ^
letscube-client:test:ci:       16 |
letscube-client:test:ci:       17 | const flushPlayerLoad = () => act(async () => {
letscube-client:test:ci:       18 |   await Promise.resolve();
letscube-client:test:ci: 
letscube-client:test:ci:       at printWarning (../node_modules/react-dom/cjs/react-dom.development.js:86:30)
letscube-client:test:ci:       at error (../node_modules/react-dom/cjs/react-dom.development.js:60:7)
letscube-client:test:ci:       at validateFunctionComponentInDev (../node_modules/react-dom/cjs/react-dom.development.js:20230:9)
letscube-client:test:ci:       at mountIndeterminateComponent (../node_modules/react-dom/cjs/react-dom.development.js:20189:7)
letscube-client:test:ci:       at beginWork (../node_modules/react-dom/cjs/react-dom.development.js:21626:16)
letscube-client:test:ci:       at beginWork$1 (../node_modules/react-dom/cjs/react-dom.development.js:27465:14)
letscube-client:test:ci:       at performUnitOfWork (../node_modules/react-dom/cjs/react-dom.development.js:26599:12)
letscube-client:test:ci:       at workLoopSync (../node_modules/react-dom/cjs/react-dom.development.js:26505:5)
letscube-client:test:ci:       at renderRootSync (../node_modules/react-dom/cjs/react-dom.development.js:26473:7)
letscube-client:test:ci:       at performConcurrentWorkOnRoot (../node_modules/react-dom/cjs/react-dom.development.js:25777:74)
letscube-client:test:ci:       at flushActQueue (../node_modules/react/cjs/react.development.js:2667:24)
letscube-client:test:ci:       at act (../node_modules/react/cjs/react.development.js:2582:11)
letscube-client:test:ci:       at ../node_modules/@testing-library/react/dist/act-compat.js:46:25
letscube-client:test:ci:       at renderRoot (../node_modules/@testing-library/react/dist/pure.js:189:26)
letscube-client:test:ci:       at render (../node_modules/@testing-library/react/dist/pure.js:291:10)
letscube-client:test:ci:       at renderPreview (src/components/common/ScramblePreview.test.jsx:15:42)
letscube-client:test:ci:       at Object.renderPreview (src/components/common/ScramblePreview.test.jsx:43:25)
letscube-client:test:ci: 
letscube-client:test:ci:     console.error
letscube-client:test:ci:       Warning: Scramble: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
letscube-client:test:ci:           at event (/tmp/letscube-codeql-fixture-security/client/src/components/common/Scramble.jsx:43:3)
letscube-client:test:ci:           at div
letscube-client:test:ci:           at /tmp/letscube-codeql-fixture-security/node_modules/@emotion/react/dist/emotion-element-25f9958c.browser.cjs.js:56:23
letscube-client:test:ci:           at DialogContent (/tmp/letscube-codeql-fixture-security/node_modules/@mui/material/node/DialogContent/DialogContent.js:68:59)
letscube-client:test:ci:           at div
letscube-client:test:ci:           at /tmp/letscube-codeql-fixture-security/node_modules/@emotion/react/dist/emotion-element-25f9958c.browser.cjs.js:56:23
letscube-client:test:ci:           at Paper (/tmp/letscube-codeql-fixture-security/node_modules/@mui/material/node/Paper/Paper.js:75:59)
letscube-client:test:ci:           at /tmp/letscube-codeql-fixture-security/node_modules/@emotion/react/dist/emotion-element-25f9958c.browser.cjs.js:56:23
letscube-client:test:ci:           at div
letscube-client:test:ci:           at /tmp/letscube-codeql-fixture-security/node_modules/@emotion/react/dist/emotion-element-25f9958c.browser.cjs.js:56:23
letscube-client:test:ci:           at Transition (/tmp/letscube-codeql-fixture-security/node_modules/react-transition-group/cjs/Transition.js:135:30)
letscube-client:test:ci:           at Fade (/tmp/letscube-codeql-fixture-security/node_modules/@mui/material/node/Fade/Fade.js:33:42)
letscube-client:test:ci:           at FocusTrap (/tmp/letscube-codeql-fixture-security/node_modules/@mui/material/node/Unstable_TrapFocus/FocusTrap.js:85:5)
letscube-client:test:ci:           at div
letscube-client:test:ci:           at /tmp/letscube-codeql-fixture-security/node_modules/@emotion/react/dist/emotion-element-25f9958c.browser.cjs.js:56:23
letscube-client:test:ci:           at Portal (/tmp/letscube-codeql-fixture-security/node_modules/@mui/material/node/Portal/Portal.js:32:5)
letscube-client:test:ci:           at Modal (/tmp/letscube-codeql-fixture-security/node_modules/@mui/material/node/Modal/Modal.js:89:59)
letscube-client:test:ci:           at /tmp/letscube-codeql-fixture-security/node_modules/@emotion/react/dist/emotion-element-25f9958c.browser.cjs.js:56:23
letscube-client:test:ci:           at Dialog (/tmp/letscube-codeql-fixture-security/node_modules/@mui/material/node/Dialog/Dialog.js:201:59)
letscube-client:test:ci:           at event (/tmp/letscube-codeql-fixture-security/client/src/components/common/ScramblePreview.jsx:103:28)
letscube-client:test:ci:           at DefaultPropsProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/system/DefaultPropsProvider/DefaultPropsProvider.js:17:3)
letscube-client:test:ci:           at RtlProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/system/RtlProvider/index.js:15:3)
letscube-client:test:ci:           at ThemeProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/private-theming/node/ThemeProvider/ThemeProvider.js:40:5)
letscube-client:test:ci:           at ThemeProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/system/ThemeProvider/ThemeProvider.js:56:5)
letscube-client:test:ci:           at ThemeProviderNoVars (/tmp/letscube-codeql-fixture-security/node_modules/@mui/material/node/styles/ThemeProviderNoVars.js:15:10)
letscube-client:test:ci:           at ThemeProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/material/node/styles/ThemeProvider.js:16:3)
letscube-client:test:ci:           at StyledEngineProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/styled-engine/node/StyledEngineProvider/StyledEngineProvider.js:106:5)
letscube-client:test:ci:           at children (/tmp/letscube-codeql-fixture-security/client/src/theme.jsx:77:33)
letscube-client:test:ci: 
letscube-client:test:ci:       65 |   await flushPlayerLoad();
letscube-client:test:ci:       66 |
letscube-client:test:ci:     > 67 |   fireEvent.click(getByLabelText('Enlarge 777 scramble preview'));
letscube-client:test:ci:          |             ^
letscube-client:test:ci:       68 |   await flushPlayerLoad();
letscube-client:test:ci:       69 |
letscube-client:test:ci:       70 |   expect(getByLabelText('777 enlarged scramble preview')).toBeInTheDocument();
letscube-client:test:ci: 
letscube-client:test:ci:       at printWarning (../node_modules/react-dom/cjs/react-dom.development.js:86:30)
letscube-client:test:ci:       at error (../node_modules/react-dom/cjs/react-dom.development.js:60:7)
letscube-client:test:ci:       at validateFunctionComponentInDev (../node_modules/react-dom/cjs/react-dom.development.js:20230:9)
letscube-client:test:ci:       at mountIndeterminateComponent (../node_modules/react-dom/cjs/react-dom.development.js:20189:7)
letscube-client:test:ci:       at beginWork (../node_modules/react-dom/cjs/react-dom.development.js:21626:16)
letscube-client:test:ci:       at beginWork$1 (../node_modules/react-dom/cjs/react-dom.development.js:27465:14)
letscube-client:test:ci:       at performUnitOfWork (../node_modules/react-dom/cjs/react-dom.development.js:26599:12)
letscube-client:test:ci:       at workLoopSync (../node_modules/react-dom/cjs/react-dom.development.js:26505:5)
letscube-client:test:ci:       at renderRootSync (../node_modules/react-dom/cjs/react-dom.development.js:26473:7)
letscube-client:test:ci:       at performSyncWorkOnRoot (../node_modules/react-dom/cjs/react-dom.development.js:26124:20)
letscube-client:test:ci:       at flushSyncCallbacks (../node_modules/react-dom/cjs/react-dom.development.js:12042:22)
letscube-client:test:ci:       at flushActQueue (../node_modules/react/cjs/react.development.js:2667:24)
letscube-client:test:ci:       at act (../node_modules/react/cjs/react.development.js:2582:11)
letscube-client:test:ci:       at ../node_modules/@testing-library/react/dist/act-compat.js:46:25
letscube-client:test:ci:       at Object.eventWrapper (../node_modules/@testing-library/react/dist/pure.js:106:28)
letscube-client:test:ci:       at fireEvent (../node_modules/@testing-library/dom/dist/events.js:12:35)
letscube-client:test:ci:       at Function.fireEvent.<computed> [as click] (../node_modules/@testing-library/dom/dist/events.js:110:36)
letscube-client:test:ci:       at Function.fireEvent.<computed> [as click] (../node_modules/@testing-library/react/dist/fire-event.js:15:52)
letscube-client:test:ci:       at Object.click (src/components/common/ScramblePreview.test.jsx:67:13)
letscube-client:test:ci: 
letscube-client:test:ci: PASS src/store/middlewares/rooms.test.js
letscube-client:test:ci: PASS src/components/Room/Common/Main.test.jsx
letscube-client:test:ci: PASS src/components/App.test.jsx
letscube-client:test:ci: PASS src/components/Navigation.test.jsx
letscube-client:test:ci:   ● Console
letscube-client:test:ci: 
letscube-client:test:ci:     console.error
letscube-client:test:ci:       Warning: GlobalPendingResultAlert: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
letscube-client:test:ci:           at atPendingRoom (/tmp/letscube-codeql-fixture-security/client/src/components/Navigation.jsx:42:3)
letscube-client:test:ci: 
letscube-client:test:ci:       38 |   it('keeps discard accessible when the pending room could not be joined', () => {
letscube-client:test:ci:       39 |     const onDiscard = jest.fn();
letscube-client:test:ci:     > 40 |     render(
letscube-client:test:ci:          |           ^
letscube-client:test:ci:       41 |       <GlobalPendingResultAlert
letscube-client:test:ci:       42 |         atPendingRoom
letscube-client:test:ci:       43 |         onDiscard={onDiscard}
letscube-client:test:ci: 
letscube-client:test:ci:       at printWarning (../node_modules/react-dom/cjs/react-dom.development.js:86:30)
letscube-client:test:ci:       at error (../node_modules/react-dom/cjs/react-dom.development.js:60:7)
letscube-client:test:ci:       at validateFunctionComponentInDev (../node_modules/react-dom/cjs/react-dom.development.js:20230:9)
letscube-client:test:ci:       at mountIndeterminateComponent (../node_modules/react-dom/cjs/react-dom.development.js:20189:7)
letscube-client:test:ci:       at beginWork (../node_modules/react-dom/cjs/react-dom.development.js:21626:16)
letscube-client:test:ci:       at beginWork$1 (../node_modules/react-dom/cjs/react-dom.development.js:27465:14)
letscube-client:test:ci:       at performUnitOfWork (../node_modules/react-dom/cjs/react-dom.development.js:26599:12)
letscube-client:test:ci:       at workLoopSync (../node_modules/react-dom/cjs/react-dom.development.js:26505:5)
letscube-client:test:ci:       at renderRootSync (../node_modules/react-dom/cjs/react-dom.development.js:26473:7)
letscube-client:test:ci:       at performConcurrentWorkOnRoot (../node_modules/react-dom/cjs/react-dom.development.js:25777:74)
letscube-client:test:ci:       at flushActQueue (../node_modules/react/cjs/react.development.js:2667:24)
letscube-client:test:ci:       at act (../node_modules/react/cjs/react.development.js:2582:11)
letscube-client:test:ci:       at ../node_modules/@testing-library/react/dist/act-compat.js:46:25
letscube-client:test:ci:       at renderRoot (../node_modules/@testing-library/react/dist/pure.js:189:26)
letscube-client:test:ci:       at render (../node_modules/@testing-library/react/dist/pure.js:291:10)
letscube-client:test:ci:       at Object.<anonymous> (src/components/Navigation.test.jsx:40:11)
letscube-client:test:ci: 
letscube-client:test:ci: PASS src/components/RoomConfigureDialog.test.jsx
letscube-client:test:ci:   ● Console
letscube-client:test:ci: 
letscube-client:test:ci:     console.error
letscube-client:test:ci:       Warning: RoomConfigureDialog: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
letscube-client:test:ci:           at room (/tmp/letscube-codeql-fixture-security/client/src/components/RoomConfigureDialog.jsx:45:3)
letscube-client:test:ci:           at DefaultPropsProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/system/DefaultPropsProvider/DefaultPropsProvider.js:17:3)
letscube-client:test:ci:           at RtlProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/system/RtlProvider/index.js:15:3)
letscube-client:test:ci:           at ThemeProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/private-theming/node/ThemeProvider/ThemeProvider.js:40:5)
letscube-client:test:ci:           at ThemeProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/system/ThemeProvider/ThemeProvider.js:56:5)
letscube-client:test:ci:           at ThemeProviderNoVars (/tmp/letscube-codeql-fixture-security/node_modules/@mui/material/node/styles/ThemeProviderNoVars.js:15:10)
letscube-client:test:ci:           at ThemeProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/material/node/styles/ThemeProvider.js:16:3)
letscube-client:test:ci:           at StyledEngineProvider (/tmp/letscube-codeql-fixture-security/node_modules/@mui/styled-engine/node/StyledEngineProvider/StyledEngineProvider.js:106:5)
letscube-client:test:ci:           at children (/tmp/letscube-codeql-fixture-security/client/src/theme.jsx:77:33)
letscube-client:test:ci: 
letscube-client:test:ci:       14 | };
letscube-client:test:ci:       15 |
letscube-client:test:ci:     > 16 | const renderDialog = (props) => render(
letscube-client:test:ci:          |                                       ^
letscube-client:test:ci:       17 |   <ThemeProvider>
letscube-client:test:ci:       18 |     <RoomConfigureDialog {...props} />
letscube-client:test:ci:       19 |   </ThemeProvider>,
letscube-client:test:ci: 
letscube-client:test:ci:       at printWarning (../node_modules/react-dom/cjs/react-dom.development.js:86:30)
letscube-client:test:ci:       at error (../node_modules/react-dom/cjs/react-dom.development.js:60:7)
letscube-client:test:ci:       at validateFunctionComponentInDev (../node_modules/react-dom/cjs/react-dom.development.js:20230:9)
letscube-client:test:ci:       at mountIndeterminateComponent (../node_modules/react-dom/cjs/react-dom.development.js:20189:7)
letscube-client:test:ci:       at beginWork (../node_modules/react-dom/cjs/react-dom.development.js:21626:16)
letscube-client:test:ci:       at beginWork$1 (../node_modules/react-dom/cjs/react-dom.development.js:27465:14)
letscube-client:test:ci:       at performUnitOfWork (../node_modules/react-dom/cjs/react-dom.development.js:26599:12)
letscube-client:test:ci:       at workLoopSync (../node_modules/react-dom/cjs/react-dom.development.js:26505:5)
letscube-client:test:ci:       at renderRootSync (../node_modules/react-dom/cjs/react-dom.development.js:26473:7)
letscube-client:test:ci:       at performConcurrentWorkOnRoot (../node_modules/react-dom/cjs/react-dom.development.js:25777:74)
letscube-client:test:ci:       at flushActQueue (../node_modules/react/cjs/react.development.js:2667:24)
letscube-client:test:ci:       at act (../node_modules/react/cjs/react.development.js:2582:11)
letscube-client:test:ci:       at ../node_modules/@testing-library/react/dist/act-compat.js:46:25
letscube-client:test:ci:       at renderRoot (../node_modules/@testing-library/react/dist/pure.js:189:26)
letscube-client:test:ci:       at render (../node_modules/@testing-library/react/dist/pure.js:291:10)
letscube-client:test:ci:       at renderDialog (src/components/RoomConfigureDialog.test.jsx:16:39)
letscube-client:test:ci:       at Object.renderDialog (src/components/RoomConfigureDialog.test.jsx:25:5)
letscube-client:test:ci: 
letscube-client:test:ci: 
letscube-client:test:ci: Test Suites: 20 passed, 20 total
letscube-client:test:ci: Tests:       97 passed, 97 total
letscube-client:test:ci: Snapshots:   0 total
letscube-client:test:ci: Time:        4.748 s
letscube-client:test:ci: Ran all test suites.
letscube-client:test:ci: Done in 5.08s.

 Tasks:    3 successful, 3 total
Cached:    3 cached, 3 total
  Time:    14ms >>> FULL TURBO

Done in 0.08s.
- 