### PR TITLE
Rate-limit authentication routes

### DIFF
--- a/server/auth/index.js
+++ b/server/auth/index.js
@@ -1,10 +1,12 @@
 const express = require('express');
+const rateLimit = require('express-rate-limit');
 const CustomStrategy = require('passport-custom').Strategy;
 const { URLSearchParams } = require('url');
 const { User } = require('../models');
 const metrics = require('../metrics');
 const { buildWcaUserUpdate } = require('./wcaProfile');
 const { upsertTestUser } = require('./testUser');
+const { apiRateLimitOptions } = require('../middlewares/apiRateLimit');
 
 const checkStatus = async (res) => {
   if (res.ok) { // res.status >= 200 && res.status < 300
@@ -21,11 +23,13 @@ const deserializeUser = async (userModel, id, done) => {
   }
 };
 
-module.exports = (app, passport) => {
+module.exports = (app, passport, rateLimitOptions = apiRateLimitOptions()) => {
   const router = express.Router();
   const config = app.get('config');
   const tokenURL = `${config.wcaSource}/oauth/token`;
   const userProfileURL = `${config.wcaSource}/api/v0/me`;
+
+  router.use(rateLimit(rateLimitOptions));
 
   passport.use('custom', new CustomStrategy(async (req, done) => {
     const { code, redirectUri } = req.body;

--- a/server/auth/index.test.js
+++ b/server/auth/index.test.js
@@ -2,6 +2,29 @@
 /* eslint-env jest */
 
 const { deserializeUser } = require('./index');
+const http = require('http');
+const express = require('express');
+const createAuthRouter = require('./index');
+const { apiRateLimitOptions } = require('../middlewares/apiRateLimit');
+
+const request = (server) => new Promise((resolve, reject) => {
+  const req = http.request({
+    host: '127.0.0.1',
+    method: 'POST',
+    path: '/auth/logout',
+    port: server.address().port,
+  }, (res) => {
+    let body = '';
+    res.on('data', (chunk) => { body += chunk; });
+    res.resume();
+    res.on('end', () => resolve({
+      body: body ? JSON.parse(body) : null,
+      status: res.statusCode,
+    }));
+  });
+  req.on('error', reject);
+  req.end();
+});
 
 describe('session user deserialization', () => {
   it('uses the Mongoose promise API and returns the loaded user', async () => {
@@ -23,5 +46,47 @@ describe('session user deserialization', () => {
     await deserializeUser(User, 990001, done);
 
     expect(done).toHaveBeenCalledWith(error);
+  });
+});
+
+describe('authentication rate limiting', () => {
+  let server;
+
+  beforeEach((done) => {
+    const app = express();
+    const passport = {
+      deserializeUser: jest.fn(),
+      serializeUser: jest.fn(),
+      use: jest.fn(),
+    };
+    app.set('config', {
+      auth: {},
+      wcaSource: 'https://wca.example',
+    });
+    app.use((req, res, next) => {
+      req.logout = (callback) => callback();
+      next();
+    });
+    app.use('/auth', createAuthRouter(
+      app,
+      passport,
+      apiRateLimitOptions({ limit: 1, windowMs: 60_000 }),
+    ));
+    server = app.listen(0, '127.0.0.1', () => done());
+  });
+
+  afterEach((done) => {
+    server.close(() => done());
+  });
+
+  it('rejects requests beyond the configured IP window', async () => {
+    expect(await request(server)).toEqual({ body: null, status: 204 });
+    expect(await request(server)).toEqual({
+      body: {
+        code: 'rate_limited',
+        message: 'Too many requests. Please try again later.',
+      },
+      status: 429,
+    });
   });
 });


### PR DESCRIPTION
## Summary

- apply the established request rate limit to the authentication router
- protect login-code exchange and logout routes outside the existing API limiter
- add a real router regression test for the standard 429 response

## Why

The authentication router was not mounted below the existing API-wide limiter. Repeated authentication requests were therefore not throttled by the application policy.

## User impact

Normal sign-in and logout continue to work within the existing 300 requests per 15-minute IP window. Excessive requests receive the established rate_limited response. No email-related behavior is added or changed.

## Validation

- focused authentication router test
- server lint
- full workspace tests: 210 server, 97 client, 22 scramble tests
- git diff check

Closes #239.