### PR TITLE
Fix lobby room list scrolling

### DIFF
--- a/client/src/components/Lobby/index.jsx
+++ b/client/src/components/Lobby/index.jsx
@@ -44,11 +44,14 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: 'column',
     flexGrow: 1,
     height: '100%',
+    minHeight: 0,
   },
   roomList: {
     display: 'flex',
     flexDirection: 'column',
     flexGrow: 1,
+    height: '100%',
+    minHeight: 0,
   },
   roomListContainer: {
     display: 'flex',
@@ -79,10 +82,12 @@ const useStyles = makeStyles((theme) => ({
     display: 'flex',
     flexDirection: 'column',
     flexGrow: 1,
+    height: '100%',
   },
   flexGrow: {
     display: 'flex',
     flexGrow: 1,
+    minHeight: 0,
   },
   bottomNav: {
     width: '100%',
@@ -147,6 +152,7 @@ function Lobby({
         >
           <div
             className={classes.roomListContainer}
+            data-testid="room-list-scroll-container"
           >
             <Container
               maxWidth="md"

--- a/client/src/components/Navigation.jsx
+++ b/client/src/components/Navigation.jsx
@@ -140,6 +140,7 @@ const useStyles = makeStyles((theme) => ({
   content: {
     display: 'flex',
     flexGrow: 1,
+    minHeight: 0,
     flexDirection: 'column',
   },
 }));

--- a/cypress/e2e/local_stack.cy.js
+++ b/cypress/e2e/local_stack.cy.js
@@ -53,6 +53,25 @@ describe('local app stack', () => {
     });
   });
 
+  it('scrolls the room list when it exceeds the viewport', () => {
+    cy.viewport(800, 500);
+    cy.visit('/');
+
+    cy.get('[data-testid="room-list-scroll-container"]', { timeout: 10000 })
+      .then(($roomList) => {
+        const filler = $roomList[0].ownerDocument.createElement('div');
+        filler.style.flex = '0 0 1000px';
+        $roomList[0].appendChild(filler);
+      })
+      .should(($roomList) => {
+        expect($roomList[0].scrollHeight).to.be.greaterThan($roomList[0].clientHeight);
+      })
+      .scrollTo('bottom')
+      .should(($roomList) => {
+        expect($roomList[0].scrollTop).to.be.greaterThan(0);
+      });
+  });
+
   it('renders markdown announcements in the lobby', () => {
     cy.intercept('GET', '**/api/announcements', '[Docs](https://example.com)').as('announcements');
 


### PR DESCRIPTION
## What changed

- constrain the lobby flex hierarchy to the available viewport height
- keep both room and user panels bounded within the Material UI Grid row
- add a Cypress regression that forces overflow in a short viewport and verifies real scroll movement

## Root cause

The room list declared `overflow-y: auto`, but flex and Grid ancestors remained content-sized. The room panel therefore grew beyond the viewport instead of giving the list a bounded scroll area; global page overflow then clipped the remaining rooms.

## User impact

Users can scroll through all public and private rooms again, including in short and mobile-sized viewports.

## Validation

- `yarn workspace letscube-client lint` (passes; existing warnings only)
- `yarn workspace letscube-client test:ci --runInBand` (97/97)
- `yarn workspace letscube-client build`
- `yarn cypress:run --spec cypress/e2e/local_stack.cy.js` (11/11)
- `git diff --check`
- full committed diff reviewed with no findings