### PR TITLE
Promote lobby scrolling fix to production

### DIFF
--- a/client/src/components/Lobby/index.jsx
+++ b/client/src/components/Lobby/index.jsx
@@ -44,11 +44,14 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: 'column',
     flexGrow: 1,
     height: '100%',
+    minHeight: 0,
   },
   roomList: {
     display: 'flex',
     flexDirection: 'column',
     flexGrow: 1,
+    height: '100%',
+    minHeight: 0,
   },
   roomListContainer: {
     display: 'flex',
@@ -79,10 +82,12 @@ const useStyles = makeStyles((theme) => ({
     display: 'flex',
     flexDirection: 'column',
     flexGrow: 1,
+    height: '100%',
   },
   flexGrow: {
     display: 'flex',
     flexGrow: 1,
+    minHeight: 0,
   },
   bottomNav: {
     width: '100%',
@@ -147,6 +152,7 @@ function Lobby({
         >
           <div
             className={classes.roomListContainer}
+            data-testid="room-list-scroll-container"
           >
             <Container
               maxWidth="md"

--- a/client/src/components/Navigation.jsx
+++ b/client/src/components/Navigation.jsx
@@ -140,6 +140,7 @@ const useStyles = makeStyles((theme) => ({
   content: {
     display: 'flex',
     flexGrow: 1,
+    minHeight: 0,
     flexDirection: 'column',
   },
 }));

--- a/cypress/e2e/local_stack.cy.js
+++ b/cypress/e2e/local_stack.cy.js
@@ -53,6 +53,25 @@ describe('local app stack', () => {
     });
   });
 
+  it('scrolls the room list when it exceeds the viewport', () => {
+    cy.viewport(800, 500);
+    cy.visit('/');
+
+    cy.get('[data-testid="room-list-scroll-container"]', { timeout: 10000 })
+      .then(($roomList) => {
+        const filler = $roomList[0].ownerDocument.createElement('div');
+        filler.style.flex = '0 0 1000px';
+        $roomList[0].appendChild(filler);
+      })
+      .should(($roomList) => {
+        expect($roomList[0].scrollHeight).to.be.greaterThan($roomList[0].clientHeight);
+      })
+      .scrollTo('bottom')
+      .should(($roomList) => {
+        expect($roomList[0].scrollTop).to.be.greaterThan(0);
+      });
+  });
+
   it('renders markdown announcements in the lobby', () => {
     cy.intercept('GET', '**/api/announcements', '[Docs](https://example.com)').as('announcements');
 


### PR DESCRIPTION
## Release candidate

Promote exact `dev` commit `92052e3b7d95f481ed9b17d1b2e00238ff827814` to `master`.

## Included change

- [#259](https://github.com/coder13/LetsCube/pull/259) — fix lobby room-list scrolling in short/mobile viewports
- reviewed committed diff with no findings
- no schema migrations or backfill

## Candidate validation

- [CI push run](https://github.com/coder13/LetsCube/actions/runs/29623407809) — client, server, production configuration/backup rehearsal, and Cypress passed
- [CodeQL push run](https://github.com/coder13/LetsCube/actions/runs/29623407789) — passed
- local client lint (existing warnings only), 97/97 client tests, production build, and 11/11 full-stack Cypress scenarios passed

## Deployment and rollback

- intended target: `api` (client-only change; API container serves the static client)
- deploy using `scripts/deploy.sh` after the `master` push checks pass
- rollback: the deploy script snapshots the currently running API image and automatically restores it if readiness or nginx reload fails