### PR TITLE
Restore conventional Clock and 2x2 scrambles

### DIFF
--- a/packages/scrambles/README.md
+++ b/packages/scrambles/README.md
@@ -30,8 +30,9 @@ details so Vite can consume it as a stable default export.
 Provider selection is explicit in `index.js`:
 
 - cubing.js is preferred for the events listed in `cubingEventIds`;
-- Scrambow handles custom practice events such as PLL, ZBLL, LSE, RU, and
-  optimal Clock; and
+- Scrambow handles 2x2 and Clock to preserve R/U/F 2x2 notation and the
+  conventional WCA Clock pin order, as well as custom practice events such as
+  PLL, ZBLL, LSE, RU, and optimal Clock; and
 - unknown event IDs are rejected.
 
 Do not treat Scrambow as a fallback for arbitrary cubing.js failures. A provider

--- a/packages/scrambles/index.js
+++ b/packages/scrambles/index.js
@@ -3,7 +3,6 @@ const { generateCubingScramble } = require('./providers/cubing');
 const { generateScrambowScramble } = require('./providers/scrambow');
 
 const cubingEventIds = new Set([
-  '222',
   '333',
   '333bf',
   '333oh',
@@ -16,7 +15,6 @@ const cubingEventIds = new Set([
   '777',
   'minx',
   'pyram',
-  'clock',
   'skewb',
   'sq1',
   'fto',

--- a/packages/scrambles/index.test.js
+++ b/packages/scrambles/index.test.js
@@ -13,7 +13,6 @@ const { generateCubingScramble } = require('./providers/cubing');
 const { generateScrambowScramble } = require('./providers/scrambow');
 
 const cubingEventIds = [
-  '222',
   '333',
   '333bf',
   '333oh',
@@ -26,7 +25,6 @@ const cubingEventIds = [
   '777',
   'minx',
   'pyram',
-  'clock',
   'skewb',
   'sq1',
   'fto',
@@ -46,18 +44,13 @@ describe('generateScramble', () => {
     expect(generateScrambowScramble).not.toHaveBeenCalled();
   });
 
-  it('uses Scrambow for the custom practice events', async () => {
-    await expect(generateScramble('clock-optimal')).resolves.toBe('scrambow scramble');
-    await expect(generateScramble('pll')).resolves.toBe('scrambow scramble');
-    await expect(generateScramble('zbll')).resolves.toBe('scrambow scramble');
-    await expect(generateScramble('lse')).resolves.toBe('scrambow scramble');
-    await expect(generateScramble('ru')).resolves.toBe('scrambow scramble');
+  it('uses Scrambow for conventional Clock and 2x2 notation and custom practice events', async () => {
+    const scrambowEvents = ['222', 'clock', 'clock-optimal', 'pll', 'zbll', 'lse', 'ru'];
 
-    expect(generateScrambowScramble).toHaveBeenNthCalledWith(1, 'clock-optimal');
-    expect(generateScrambowScramble).toHaveBeenNthCalledWith(2, 'pll');
-    expect(generateScrambowScramble).toHaveBeenNthCalledWith(3, 'zbll');
-    expect(generateScrambowScramble).toHaveBeenNthCalledWith(4, 'lse');
-    expect(generateScrambowScramble).toHaveBeenNthCalledWith(5, 'ru');
+    await Promise.all(scrambowEvents.map((eventId) => expect(generateScramble(eventId)).resolves.toBe('scrambow scramble')));
+
+    expect(generateCubingScramble).not.toHaveBeenCalled();
+    expect(generateScrambowScramble.mock.calls.map(([eventId]) => eventId)).toEqual(scrambowEvents);
   });
 
   it('rejects events that are not in the shared catalog', async () => {
@@ -80,6 +73,8 @@ describe('events', () => {
   it('contains every event supported by the generator', () => {
     expect(events.map(({ id }) => id)).toEqual(expect.arrayContaining([
       ...cubingEventIds,
+      '222',
+      'clock',
       'clock-optimal',
       'pll',
       'zbll',


### PR DESCRIPTION
## Summary

Restore Scrambow for Clock and 2×2 scrambles.

- Clock returns to the conventional `UR DR DL UL … y2 …` pin order.
- 2×2 returns to R/U/F-only notation.
- Document the routing policy and cover both routes in provider tests.

## Root cause

The shared scramble-provider migration routed both events through cubing.js, changing Clock's displayed pin order and 2×2 notation.

## Validation

- `eslint index.js index.test.js`
- `jest --passWithNoTests` (20 tests)
- Real generation smoke test: Clock starts `UR DR DL UL`; 2×2 contains only R/U/F moves.